### PR TITLE
Pupil lint fixes

### DIFF
--- a/pupil/assets/javascripts/speedcheck.js
+++ b/pupil/assets/javascripts/speedcheck.js
@@ -1,6 +1,7 @@
-(function(global) {
-  'use strict';
-  var GOVUK = global.GOVUK || {};
+/* global $ ga */
+(function (global) {
+  'use strict'
+  var GOVUK = global.GOVUK || {}
 
   GOVUK.speedTest = {
     startTime: null,
@@ -21,7 +22,7 @@
       '16mb.text',
       '32mb.text',
       '64mb.text',
-      '128mb.text',
+      '128mb.text'
     ],
     baseFilePath: '/data/',
 
@@ -32,110 +33,110 @@
      * @returns {boolean}
      */
     control: function (timeTaken, size) {
-      var downloadSpeedKbps = 0;
-      var file = '';
+      var downloadSpeedKbps = 0
+      var file = ''
 
       if (!$.isNumeric(timeTaken)) {
-        return false;
+        return false
       }
 
       if (timeTaken >= GOVUK.speedTest.minimumTransferTime || GOVUK.speedTest.isLastFile()) {
         // we are prepared to accept this
-        downloadSpeedKbps = this.calculate(size, timeTaken);
-        this.downloadSpeedKbps = downloadSpeedKbps;
+        downloadSpeedKbps = this.calculate(size, timeTaken)
+        this.downloadSpeedKbps = downloadSpeedKbps
         // ga('set', 'metric1', downloadSpeedKbps);
-        this.ui.showSuccess();
-        return true;
+        this.ui.showSuccess()
+        return true
       }
 
-      this.downloadIndex += 1;
-      file = this.files[this.downloadIndex];
-      this.download(file);
-      return true;
+      this.downloadIndex += 1
+      file = this.files[this.downloadIndex]
+      this.download(file)
+      return true
     },
 
     isLastFile: function () {
-      var i = 1;
+      var i = 1
       // We dont want to give the 128M file to IE8 at it wont work.
       if (GOVUK.speedTest.isIE8() && GOVUK.speedTest.downloadIndex === 9) {
-        return true;
+        return true
       }
-      return (GOVUK.speedTest.downloadIndex + i) === GOVUK.speedTest.files.length;
+      return (GOVUK.speedTest.downloadIndex + i) === GOVUK.speedTest.files.length
     },
 
     isIE8: function () {
       if (document.addEventListener) {
-        return false;
+        return false
       }
-      return true;
+      return true
     },
 
     ui: {
       round2: function (num) {
-        return Math.round(num * 100) / 100;
+        return Math.round(num * 100) / 100
       },
 
       showInProgress: function () {
-        $('div.section').addClass('hidden');
-        $('div.js-in-progress').removeClass('hidden');
+        $('div.section').addClass('hidden')
+        $('div.js-in-progress').removeClass('hidden')
 
         if (global.ga) {
-          ga('send', 'event', 'speedTest', 'in-progress', 'Speed Test');
+          ga('send', 'event', 'speedTest', 'in-progress', 'Speed Test')
         }
       },
 
       showSuccess: function () {
-        $('div.section').addClass('hidden');
-        $('div.js-success').removeClass('hidden');
+        $('div.section').addClass('hidden')
+        $('div.js-success').removeClass('hidden')
         // send the data to the back end
         var data = {
           downloadSpeedKbps: GOVUK.speedTest.downloadSpeedKbps,
           resolution: global.screen.width + 'x' + global.screen.height
-        };
-        $.get('/logger', data);
+        }
+        $.get('/logger', data)
         if (global.ga) {
           ga('send', 'event', 'speedTest', 'success', 'Speed Test', {
             metric1: GOVUK.speedTest.downloadSpeedKbps
-          });
+          })
         }
       },
 
       showError: function () {
-        $('div.section').addClass('hidden');
-        $('div.js-error').removeClass('hidden');
+        $('div.section').addClass('hidden')
+        $('div.js-error').removeClass('hidden')
         if (global.ga) {
-          ga('send', 'event', 'speedTest', 'error', 'Speed Test');
+          ga('send', 'event', 'speedTest', 'error', 'Speed Test')
         }
       },
 
       getSpeedTestResult: function (kbps) {
         if (kbps / 1024 >= 1024) {
-          return this.round2(kbps / 1024 / 1024).toString() + ' Gbps';
+          return this.round2(kbps / 1024 / 1024).toString() + ' Gbps'
         } else if (kbps >= 1024) {
-          return this.round2(kbps / 1024).toString() + ' Mbps';
+          return this.round2(kbps / 1024).toString() + ' Mbps'
         } else {
-          return this.round2(kbps).toString() + ' Kbps';
+          return this.round2(kbps).toString() + ' Kbps'
         }
       }
     }, // ui
 
     start: function () {
-      var self = GOVUK.speedTest;
+      var self = GOVUK.speedTest
 
-      self.ui.showInProgress();
-      self.downloadIndex = 0;
-      self.sessionStartTime = new Date().getTime();
-      self.startDownload();
+      self.ui.showInProgress()
+      self.downloadIndex = 0
+      self.sessionStartTime = new Date().getTime()
+      self.startDownload()
     },
 
     startDownload: function () {
-      var file = this.files[this.downloadIndex];
-      this.download(file);
+      var file = this.files[this.downloadIndex]
+      this.download(file)
     },
 
     download: function (file) {
-      this.startTime = new Date().getTime();
-      var url = this.baseFilePath + file;
+      this.startTime = new Date().getTime()
+      var url = this.baseFilePath + file
       $.ajax({
         type: 'GET',
         url: url,
@@ -145,20 +146,20 @@
         async: true,
         timeout: this.timeout,
         success: function (data, status, xhr) {
-          GOVUK.speedTest.endTime = new Date().getTime();
-          var timeTaken = GOVUK.speedTest.endTime - GOVUK.speedTest.startTime; // ms
-          GOVUK.speedTest.control(timeTaken, data.length);
+          GOVUK.speedTest.endTime = new Date().getTime()
+          var timeTaken = GOVUK.speedTest.endTime - GOVUK.speedTest.startTime // ms
+          GOVUK.speedTest.control(timeTaken, data.length)
         },
         error: function (xhr, errorType, error) {
-          console.log(errorType);
+          console.log(errorType)
           // show error
-          console.log(error);
+          console.log(error)
           if (global.ga) {
-            ga('send', 'event', 'speedTest', 'error', 'Speed Test');
+            ga('send', 'event', 'speedTest', 'error', 'Speed Test')
           }
-          GOVUK.speedTest.ui.showError();
+          GOVUK.speedTest.ui.showError()
         }
-      });
+      })
     },
 
     /**
@@ -168,13 +169,12 @@
      * @returns {number}
      */
     calculate: function (size, time) {
-      var bandwidth = size * (1000 / time); // bytes per second
-      var bandwidthKbps = Math.round((bandwidth / 1024) * 8); // Kilobits per second
-      return bandwidthKbps;
+      var bandwidth = size * (1000 / time) // bytes per second
+      var bandwidthKbps = Math.round((bandwidth / 1024) * 8) // Kilobits per second
+      return bandwidthKbps
     }
 
-  };  // speedtest
+  }  // speedtest
 
-  global.GOVUK = GOVUK;
-})(window);
-
+  global.GOVUK = GOVUK
+})(window)

--- a/pupil/bin/extract-logins-and-answers.js
+++ b/pupil/bin/extract-logins-and-answers.js
@@ -24,7 +24,7 @@ mongoose.connect(config.MONGO_CONNECTION_STRING, async function (error) {
 
   // extract all complete answers
   try {
-    answers = await Answers.find({ result : { $exists : true }, createdAt: {$gt: '2017-05-22 00:00:00'}}).sort({createdAt: 1}).exec()
+    answers = await Answers.find({ result: { $exists: true }, createdAt: {$gt: '2017-05-22 00:00:00'}}).sort({createdAt: 1}).exec()
   } catch (error) {
     console.error(error)
     process.exit(1)
@@ -34,7 +34,7 @@ mongoose.connect(config.MONGO_CONNECTION_STRING, async function (error) {
     let answer = answers[index]
     let logonEvent = null
     if (answer.logonEvent) {
-     logonEvent = await getLogon(answer.logonEvent)
+      logonEvent = await getLogon(answer.logonEvent)
     } else {
       console.log(`Logon Event not in schema`)
       logonEvent = {}
@@ -60,8 +60,7 @@ mongoose.connect(config.MONGO_CONNECTION_STRING, async function (error) {
   mongoose.connection.close()
 })
 
-
-function getLogon(logonEventId) {
+function getLogon (logonEventId) {
   return new Promise(async function (resolve, reject) {
     try {
       let logonEvent = await LogonEvent.findOne({_id: logonEventId}).exec()

--- a/pupil/gulpfile.js
+++ b/pupil/gulpfile.js
@@ -106,7 +106,6 @@ gulp.task('realclean', ['clean'], function () {
 gulp.task('build', ['sass', 'bundleJs'])
 
 gulp.task('dist', ['build'], function () {
-
   var packagePaths = ['**',
     '!**/_package/**',
     '!**/typings/**',

--- a/pupil/models/answer.js
+++ b/pupil/models/answer.js
@@ -34,7 +34,7 @@ const Answer = new Schema({
       _id: false,
       input: {type: String, required: true},
       eventType: {type: String, required: true},
-      clientInputDate: {type: Date, required: true},
+      clientInputDate: {type: Date, required: true}
     }]
   }],
   result: {

--- a/pupil/package.json
+++ b/pupil/package.json
@@ -103,5 +103,12 @@
     ],
     "all": true,
     "cache": true
+  },
+  "standard": {
+    "ignore": [
+      "public/govuk_template/**/*",
+      "assets/javascripts/modernizr-custom.js",
+      "assets/javascripts/jquery-1.12.4.js"
+    ]
   }
 }

--- a/pupil/server.js
+++ b/pupil/server.js
@@ -50,7 +50,7 @@ if (cluster.isMaster) {
  * Normalize a port into a number, string, or false.
  */
 
-function normalizePort(val) {
+function normalizePort (val) {
   let port = parseInt(val, 10)
 
   if (isNaN(port)) {
@@ -70,7 +70,7 @@ function normalizePort(val) {
  * Event listener for HTTP server "error" event.
  */
 
-function onError(error) {
+function onError (error) {
   if (error.syscall !== 'listen') {
     throw error
   }
@@ -98,7 +98,7 @@ function onError(error) {
  * Event listener for HTTP server "listening" event.
  */
 
-function onListening() {
+function onListening () {
   let addr = server.address()
   let bind = typeof addr === 'string'
     ? 'pipe ' + addr

--- a/pupil/spec/models/answer.spec.js
+++ b/pupil/spec/models/answer.spec.js
@@ -1,148 +1,146 @@
-'use strict';
+'use strict'
 
-const Answer = require('../../models/answer');
-const mongoose = require('mongoose');
-let answer;
+/* global describe beforeEach it expect */
+
+const Answer = require('../../models/answer')
+const mongoose = require('mongoose')
+let answer
 
 describe('answer schema', function () {
-
   beforeEach(function () {
     answer = new Answer({
-      sessionId: "abc123",
-      testId: "test1",
+      sessionId: 'abc123',
+      testId: 'test1',
       logonEvent: mongoose.Types.ObjectId(),
       pupil: mongoose.Types.ObjectId(),
       school: 9991001,
       creationDate: new Date(),
       answers: [{answerDate: Date.now(), factor1: 12, factor2: 1}],
-      registeredInputs: [{input: "left click", eventType: "mousedown", clientInputDate: new Date()}]
-    });
-  });
+      registeredInputs: [{input: 'left click', eventType: 'mousedown', clientInputDate: new Date()}]
+    })
+  })
 
-  it('validates a correct model', function(done) {
-    answer.validate(function(err){
-      expect(err).toBe(null);
-      done();
-    });
-  });
+  it('validates a correct model', function (done) {
+    answer.validate(function (err) {
+      expect(err).toBe(null)
+      done()
+    })
+  })
 
   it('it should be invalid if sessionId is empty', function (done) {
-    let a = new Answer();
+    let a = new Answer()
     a.validate(function (err) {
-      expect(err.errors.sessionId).toBeDefined();
-      done();
-    });
-
-  });
+      expect(err.errors.sessionId).toBeDefined()
+      done()
+    })
+  })
 
   it('it should be invalid if testId is empty', function (done) {
-    let a = new Answer();
+    let a = new Answer()
     a.validate(function (err) {
-      expect(err.errors.testId).toBeDefined();
-      done();
-    });
-  });
+      expect(err.errors.testId).toBeDefined()
+      done()
+    })
+  })
 
   it('it should be invalid if answerDate, factor1 or factor2 is empty', function (done) {
-    let a = new Answer();
-    a.answers = [{}];
+    let a = new Answer()
+    a.answers = [{}]
     a.validate(function (err) {
-      expect(err.errors.hasOwnProperty('answers.0.answerDate')).toBe(true);
-      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true);
-      expect(err.errors.hasOwnProperty('answers.0.factor2')).toBe(true);
-      done();
-    });
-  });
+      expect(err.errors.hasOwnProperty('answers.0.answerDate')).toBe(true)
+      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true)
+      expect(err.errors.hasOwnProperty('answers.0.factor2')).toBe(true)
+      done()
+    })
+  })
 
   it('negative factors should be invalid', function (done) {
-    let a = new Answer({testId: "a", sessionId: "s"});
-    a.answers = [{ answerDate: Date.now(), factor1: -1, factor2: 1 }];
+    let a = new Answer({testId: 'a', sessionId: 's'})
+    a.answers = [{ answerDate: Date.now(), factor1: -1, factor2: 1 }]
     a.validate(function (err) {
-      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true);
-      done();
-    });
-  });
+      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true)
+      done()
+    })
+  })
 
   it('factors over 12 should be invalid', function (done) {
-    let a = new Answer({testId: "a", sessionId: "s"});
-    a.answers = [{ answerDate: Date.now(), factor1: 13, factor2: 1 }];
+    let a = new Answer({testId: 'a', sessionId: 's'})
+    a.answers = [{ answerDate: Date.now(), factor1: 13, factor2: 1 }]
     a.validate(function (err) {
-      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true);
-      done();
-    });
-  });
+      expect(err.errors.hasOwnProperty('answers.0.factor1')).toBe(true)
+      done()
+    })
+  })
 
   it('the Answer model can be turned into an object without id or creationDate', function () {
-    let a = new Answer({testId: 'a', sessionId: 's'});
-    a.answers = [{ answerDate: Date.now(), factor1: 12, factor2: 1 }];
-    let res = a.toPojo();
-    expect(res.testId).toBe('a');
-    expect(res.sessionId).toBe('s');
-    expect(res._id).toBeUndefined();
-    expect(res.creationDate).toBeUndefined();
-    expect(res.answers[0]._id).toBeUndefined();
-  });
+    let a = new Answer({testId: 'a', sessionId: 's'})
+    a.answers = [{ answerDate: Date.now(), factor1: 12, factor2: 1 }]
+    let res = a.toPojo()
+    expect(res.testId).toBe('a')
+    expect(res.sessionId).toBe('s')
+    expect(res._id).toBeUndefined()
+    expect(res.creationDate).toBeUndefined()
+    expect(res.answers[0]._id).toBeUndefined()
+  })
 
-  it('can mark results', function() {
-    let a = new Answer({testId: 'a', sessionId: 's'});
+  it('can mark results', function () {
+    let a = new Answer({testId: 'a', sessionId: 's'})
     a.answers = [
       { answerDate: Date.now(), factor1: 12, factor2: 1, input: 12 },
       { answerDate: Date.now(), factor1: 2, factor2: 1, input: 0 },
       { answerDate: Date.now(), factor1: 3, factor2: 1, input: 'x' },
       { answerDate: Date.now(), factor1: 4, factor2: 1, input: '-1' },
       { answerDate: Date.now(), factor1: 5, factor2: 5, input: '5' }
-    ];
+    ]
 
-    a.markResults();
+    a.markResults()
 
-    expect(a.answers[0].isCorrect).toBeDefined();
-    expect(a.answers[0].isCorrect).toBe(true);
-    expect(a.answers[1].isCorrect).toBeDefined();
-    expect(a.answers[1].isCorrect).toBe(false);
-    expect(a.result).toBeDefined();
-    expect(a.result.correct).toBeDefined();
-    expect(a.result.correct).toBe(1);
-    expect(a.result.isPass).toBeDefined();
-    expect(a.result.isPass).toBe(false);
-    expect(a.answers[2].isCorrect).toBe(false);
+    expect(a.answers[0].isCorrect).toBeDefined()
+    expect(a.answers[0].isCorrect).toBe(true)
+    expect(a.answers[1].isCorrect).toBeDefined()
+    expect(a.answers[1].isCorrect).toBe(false)
+    expect(a.result).toBeDefined()
+    expect(a.result.correct).toBeDefined()
+    expect(a.result.correct).toBe(1)
+    expect(a.result.isPass).toBeDefined()
+    expect(a.result.isPass).toBe(false)
+    expect(a.answers[2].isCorrect).toBe(false)
+  })
 
-  });
+  it('sets creationDate automatically', function () {
+    let a = new Answer({testId: 'a', sessionId: 's'})
+    expect(a.creationDate).toBeDefined()
+  })
 
-  it('sets creationDate automatically', function() {
-    let a = new Answer({testId: "a", sessionId: "s"});
-    expect(a.creationDate).toBeDefined();
-  });
-
-  it('requires a logonEvent Id', function(done){
-    let a = new Answer({testId: "a", sessionId: "s"});
+  it('requires a logonEvent Id', function (done) {
+    let a = new Answer({testId: 'a', sessionId: 's'})
     a.validate(error => {
-      expect(error.errors.logonEvent).toBeDefined();
-      done();
-    });
+      expect(error.errors.logonEvent).toBeDefined()
+      done()
+    })
   })
 
-  it('requires a pupil', function(done) {
-    answer.pupil = undefined;
+  it('requires a pupil', function (done) {
+    answer.pupil = undefined
     answer.validate(error => {
-      expect(error.errors.pupil).toBeDefined();
-      done();
-    });
+      expect(error.errors.pupil).toBeDefined()
+      done()
+    })
   })
 
-  it('requires a school', function(done) {
-    answer.school = undefined;
+  it('requires a school', function (done) {
+    answer.school = undefined
     answer.validate(error => {
-      expect(error.errors.school).toBeDefined();
-      done();
-    });
+      expect(error.errors.school).toBeDefined()
+      done()
+    })
   })
 
-  it('electron is set by default to false', function(done) {
-    const a = new Answer();
-    a.validate(error => {
-      expect(answer.isElectron).toBe(false);
-      done();
-    });
+  it('electron is set by default to false', function (done) {
+    const a = new Answer()
+    a.validate(() => {
+      expect(answer.isElectron).toBe(false)
+      done()
+    })
   })
-
-});
+})

--- a/pupil/spec/models/feedback.spec.js
+++ b/pupil/spec/models/feedback.spec.js
@@ -1,13 +1,14 @@
-'use strict';
+'use strict'
+/* global describe it xit expect */
 
-const Feedback = require('../../models/feedback');
+const Feedback = require('../../models/feedback')
 
 const inputStates = [
   'Touchscreen',
   'Mouse',
   'Keyboard',
   'Mix of the above'
-];
+]
 
 const satisfactionStates = [
   'Very easy',
@@ -15,68 +16,67 @@ const satisfactionStates = [
   'Neither easy or difficult',
   'Difficult',
   'Very difficult'
-];
+]
 
 describe('feedback schema', function () {
+  it('sets a creationDate automatically', function () {
+    let f = new Feedback({})
+    expect(f.creationDate).toBeDefined()
+  })
 
-  it('sets a creationDate automatically', function() {
-    let f = new Feedback({});
-    expect(f.creationDate).toBeDefined();
-  });
+  xit('accepts valid states for inputType', function (done) {
+    inputStates.forEach(function (state) {
+      const f = new Feedback({ inputType: state })
+      f.validate(function (err) {
+        expect(err).toBe(null)
+        done()
+      })
+    })
+  })
 
-  xit('accepts valid states for inputType', function(done) {
-    inputStates.forEach(function(state) {
-      const f = new Feedback({ inputType: state });
-      f.validate(function(err) {
-        expect(err).toBe(null);
-        done();
-      });
-    });
-  });
-
-  xit('accepts valid states for satisfactionRating', function(done) {
-    satisfactionStates.forEach(function(state) {
-      const f = new Feedback({ satisfactionRating: state });
-      f.validate(function(err) {
-        expect(err).toBe(null);
-        done();
-      });
-    });
-  });
+  xit('accepts valid states for satisfactionRating', function (done) {
+    satisfactionStates.forEach(function (state) {
+      const f = new Feedback({ satisfactionRating: state })
+      f.validate(function (err) {
+        expect(err).toBe(null)
+        done()
+      })
+    })
+  })
 
   xit('does not accept an invalid state for satisfactionRating', function (done) {
-    const f = new Feedback({ satisfactionRating: 'invalid' });
+    const f = new Feedback({ satisfactionRating: 'invalid' })
     f.validate(function (err) {
-      expect(err.errors.satisfactionRating).toBeDefined();
-      done();
-    });
-  });
+      expect(err.errors.satisfactionRating).toBeDefined()
+      done()
+    })
+  })
 
   it('inputType is required', function (done) {
-    const f = new Feedback({});
+    const f = new Feedback({})
     f.validate(function (err) {
-      expect(err.errors.inputType).toBeDefined();
-      expect(err.errors.inputType.message).toBe('Please choose an option below');
-      done();
-    });
-  });
+      expect(err.errors.inputType).toBeDefined()
+      expect(err.errors.inputType.message).toBe('Please choose an option below')
+      done()
+    })
+  })
 
   it('satisfactionRating is required', function (done) {
-    const f = new Feedback({});
+    const f = new Feedback({})
     f.validate(function (err) {
-      expect(err.errors.satisfactionRating).toBeDefined();
-      expect(err.errors.satisfactionRating.message).toBe('Please choose an option below');
-      done();
-    });
-  });
+      expect(err.errors.satisfactionRating).toBeDefined()
+      expect(err.errors.satisfactionRating.message).toBe('Please choose an option below')
+      done()
+    })
+  })
 
-  it('comment has a maximum length', function(done) {
-    let c = 'x'.repeat(1201);
-    let f = new Feedback({ satisfactionRating: 'Very easy', comment: c});
-    f.validate(function(err) {
-      expect(err.errors.comment).toBeDefined();
-      expect(err.errors.comment.message).toBe('You have exceeded the word limit');
-      done();
-    });
-  });
-});
+  it('comment has a maximum length', function (done) {
+    let c = 'x'.repeat(1201)
+    let f = new Feedback({satisfactionRating: 'Very easy', comment: c})
+    f.validate(function (err) {
+      expect(err.errors.comment).toBeDefined()
+      expect(err.errors.comment.message).toBe('You have exceeded the word limit')
+      done()
+    })
+  })
+})

--- a/pupil/spec/models/logon-event.spec.js
+++ b/pupil/spec/models/logon-event.spec.js
@@ -1,67 +1,67 @@
-'use strict';
+'use strict'
+/* global describe it expect */
 
-const LogonEvent = require('../../models/logon-event');
+const LogonEvent = require('../../models/logon-event')
 
 describe('logon event schema', function () {
-
   it('requires a sessionId', function (done) {
-    let e = new LogonEvent();
-    e.validate(function(err) {
-      expect(err).toBeDefined();
-      expect(err.errors).toBeDefined();
-      expect(err.errors.sessionId).toBeDefined();
-      done();
-    });
-  });
+    let e = new LogonEvent()
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors).toBeDefined()
+      expect(err.errors.sessionId).toBeDefined()
+      done()
+    })
+  })
 
-  it('requires an isAuthenticated field', function(done) {
-    let e = new LogonEvent({sessionId: 's'});
-    e.validate(function(err) {
-      expect(err).toBeDefined();
-      expect(err.errors.isAuthenticated).toBeDefined();
-      done();
-    });
-  });
+  it('requires an isAuthenticated field', function (done) {
+    let e = new LogonEvent({sessionId: 's'})
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors.isAuthenticated).toBeDefined()
+      done()
+    })
+  })
 
-  it('trims the value of 4-digit pins', function() {
-    let s = ' input ';
-    let e = new LogonEvent({pin4Digit: s});
-    expect(e.pin4Digit).toBe('input');
-  });
+  it('trims the value of 4-digit pins', function () {
+    let s = ' input '
+    let e = new LogonEvent({pin4Digit: s})
+    expect(e.pin4Digit).toBe('input')
+  })
 
-  it('detects low invalid dobDay', function(done) {
-    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobDay: 0});
-    e.validate(function(err){
-      expect(err).toBeDefined();
-      expect(err.errors.dobDay).toBeDefined();
-      done();
-    });
-  });
+  it('detects low invalid dobDay', function (done) {
+    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobDay: 0})
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors.dobDay).toBeDefined()
+      done()
+    })
+  })
 
-  it('detects high invalid dobDay', function(done) {
-    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobDay: 32});
-    e.validate(function(err){
-      expect(err).toBeDefined();
-      expect(err.errors.dobDay).toBeDefined();
-      done();
-    });
-  });
+  it('detects high invalid dobDay', function (done) {
+    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobDay: 32})
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors.dobDay).toBeDefined()
+      done()
+    })
+  })
 
-  it('detects low invalid dobMonth', function(done) {
-    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobMonth: 0});
-    e.validate(function(err){
-      expect(err).toBeDefined();
-      expect(err.errors.dobMonth).toBeDefined();
-      done();
-    });
-  });
+  it('detects low invalid dobMonth', function (done) {
+    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobMonth: 0})
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors.dobMonth).toBeDefined()
+      done()
+    })
+  })
 
-  it('detects high invalid dobMonth', function(done) {
-    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobMonth: 13});
-    e.validate(function(err){
-      expect(err).toBeDefined();
-      expect(err.errors.dobMonth).toBeDefined();
-      done();
-    });
-  });
-});
+  it('detects high invalid dobMonth', function (done) {
+    let e = new LogonEvent({sessionId: 's', isAuthenticated: true, dobMonth: 13})
+    e.validate(function (err) {
+      expect(err).toBeDefined()
+      expect(err.errors.dobMonth).toBeDefined()
+      done()
+    })
+  })
+})


### PR DESCRIPTION
Some lint fixes for the pupil app.  The biggest win is ignoring the vendor javascript which was causing reams of output to appear when running `standard` from the cli.

Current output is now more manageable as it is only a few lines.  

