### PR TITLE
Add script to deploy admin to heroku

### DIFF
--- a/dirty-deploy-heroku-admin.sh
+++ b/dirty-deploy-heroku-admin.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -x
+
+CWD=`pwd`
+ADMIN_APP="$CWD/admin"
+TEMP_DIR=`mktemp -d`
+cd $TEMP_DIR
+cp -a "$ADMIN_APP" .
+cd admin
+rm -rf node_modules package-lock.json
+git init
+git add -A
+git commit -q -m 'deploying admin'
+heroku git:remote -a check-development
+git push -f heroku master
+cd $CWD
+rm -rf $TEMP_DIR
+
+
+
+
+
+

--- a/dirty-deploy-heroku-admin.sh
+++ b/dirty-deploy-heroku-admin.sh
@@ -15,9 +15,3 @@ heroku git:remote -a check-development
 git push -f heroku master
 cd $CWD
 rm -rf $TEMP_DIR
-
-
-
-
-
-


### PR DESCRIPTION
This is made problematic because we have a multi-app repository.  The fix is to create a new temp git repo and deploy from there.