### PR TITLE
Docker nginx fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,8 @@ services:
     container_name: mtc_pupil_spa
     ports:
     - "3002:80"
+    # moved from dockerfile to here as it hangs the VSO build waiting for the CMD to exit, which never does.
+    command: /bin/bash -c "sleep 2 && echo starting && nginx -g 'daemon off;'"
   pupil-app:
     build: ./pupil
     container_name: mtc_pupil

--- a/pupil-spa/Dockerfile
+++ b/pupil-spa/Dockerfile
@@ -20,5 +20,5 @@ RUN npm install \
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["nginx"]
 


### PR DESCRIPTION
The image build is hanging in VSO, likely due to the `nginx -g daemon off;` command in the dockerfile for the SPA.

Moving this command to compose.  Concerned that once deployed to Azure it will simply fire up and exit.  But one step at a time....