### PR TITLE
run ng test during travis build on SPA

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,8 @@ before_install:
 - rvm install 2.3.3
 install: true
 script:
-- sh -c 'cd pupil && npm install && npm test && cd ../admin && npm install && npm
+- sh -c 'cd pupil-spa && npm install && npm run test-single && cd ../admin && npm install && npm
   test'
 - "./admin/test.sh"
-- "./pupil/test.sh"
+# TODO enable when ready
+#- "./pupil-spa/test.sh"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 node_js:
 - 8.1.0
 addons:
+  chrome: stable
   apt:
     sources:
     - ubuntu-toolchain-r-test

--- a/pupil-spa/karma.conf.js
+++ b/pupil-spa/karma.conf.js
@@ -27,13 +27,22 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['Chrome'],
+    browsers: ['ChromeHeadless'],
     singleRun: false,
     customLaunchers: {
       Chrome_with_debugging: {
         base: 'Chrome',
         flags: ['--remote-debugging-port=9876'],
         debug: true
+      },
+      ChromeHeadless: {
+        base: 'Chrome',
+        flags: [
+          '--headless',
+          '--disable-gpu',
+          // Without a remote debugging port, Google Chrome exits immediately.
+          '--remote-debugging-port=9222'
+        ]
       }
     }
   })

--- a/pupil-spa/package.json
+++ b/pupil-spa/package.json
@@ -10,6 +10,7 @@
     "startwithgovuk": "node tools/copyGovukFrontendToolkit && node tools/copyGovukElements && ng serve",
     "build": "ng build",
     "test": "ng test",
+    "test-single": "ng test --single-run=true",
     "lint": "ng lint",
     "e2e": "ng e2e",
     "copygovuktoolkit": "node tools/copyGovukFrontendToolkit",

--- a/pupil-spa/src/app/user.service.spec.ts
+++ b/pupil-spa/src/app/user.service.spec.ts
@@ -100,9 +100,5 @@ describe('UserService', () => {
       userService.logout();
       expect(storageService.clear).toHaveBeenCalled();
     });
-
-    it('should fail the travis build', () => {
-      expect('travis').toBe('a failed build');
-    });
   });
 });

--- a/pupil-spa/src/app/user.service.spec.ts
+++ b/pupil-spa/src/app/user.service.spec.ts
@@ -100,5 +100,9 @@ describe('UserService', () => {
       userService.logout();
       expect(storageService.clear).toHaveBeenCalled();
     });
+
+    it('should fail the travis build', () => {
+      expect('travis').toBe('a failed build');
+    });
   });
 });


### PR DESCRIPTION
This PR can be considered complete when the travis build executes the unit tests via the `test-single` script added to package.json.

The pupil tests have also been omitted as this is no longer under development and will soon be removed.