### PR TITLE
strongly type Storage Keys to avoid mismatches

### DIFF
--- a/pupil-spa/src/app/login.response.mock.json
+++ b/pupil-spa/src/app/login.response.mock.json
@@ -51,6 +51,11 @@
       "factor2": 12
     }
   ],
+  "session": {
+    "SessionId": "slifjlk34f89w4jso8",
+    "AuthKey": "{K34T8GFH-3HFGKJFKSJHFJKH-4FGJSLHSDFJHF}",
+    "UserId": "{494JKRJFSF-KL34JGEO84-34E8OFHSFJH-34THEF4O8W4TH}"
+  },
   "pupil": {
     "firstName": "Pupil",
     "lastName": "One",

--- a/pupil-spa/src/app/question.service.spec.ts
+++ b/pupil-spa/src/app/question.service.spec.ts
@@ -13,7 +13,9 @@ describe('QuestionService', () => {
       getItem() {
       }
     };
-    spyOn(mockStorageService, 'getItem').and.returnValue(JSON.stringify(responseMock));
+    var questions = responseMock['questions'];
+    var config = responseMock['config'];
+    spyOn(mockStorageService, 'getItem').and.returnValues(questions, config);
     TestBed.configureTestingModule({
       providers: [
         QuestionService,
@@ -29,6 +31,8 @@ describe('QuestionService', () => {
   it('getQuestion() returns a Question', inject([QuestionService], (service: QuestionService) => {
     service.initialise();
     const q = service.getQuestion(1);
+    //console.log('question:', q);
+
     expect(q.constructor.name).toBe('Question');
     expect(q.factor1).toBe(2);
     expect(q.factor2).toBe(5);

--- a/pupil-spa/src/app/question.service.spec.ts
+++ b/pupil-spa/src/app/question.service.spec.ts
@@ -31,7 +31,6 @@ describe('QuestionService', () => {
   it('getQuestion() returns a Question', inject([QuestionService], (service: QuestionService) => {
     service.initialise();
     const q = service.getQuestion(1);
-    //console.log('question:', q);
 
     expect(q.constructor.name).toBe('Question');
     expect(q.factor1).toBe(2);

--- a/pupil-spa/src/app/question.service.ts
+++ b/pupil-spa/src/app/question.service.ts
@@ -25,10 +25,6 @@ export class QuestionService {
     }
 
     const data = this.questions[sequenceNumber - 1];
-
-    console.log('questions is ',this.questions);
-    console.log('questions[0] is ',this.questions[0]);
-
     const last = this.getNumberOfQuestions();
 
     // Bounds check

--- a/pupil-spa/src/app/question.service.ts
+++ b/pupil-spa/src/app/question.service.ts
@@ -25,6 +25,10 @@ export class QuestionService {
     }
 
     const data = this.questions[sequenceNumber - 1];
+
+    console.log('questions is ',this.questions);
+    console.log('questions[0] is ',this.questions[0]);
+
     const last = this.getNumberOfQuestions();
 
     // Bounds check
@@ -65,11 +69,14 @@ export class QuestionService {
   }
 
   initialise() {
-    const data = JSON.parse(this.storageService.getItem('data'));
-    this.questions = data['questions'];
+    const questionData = this.storageService.getItem('questions');
+    //console.log('questions:', questionData);
+    const configData = this.storageService.getItem('config');
+    //console.log('config:', configData);
+    this.questions = questionData;
     const config = new Config();
-    config.loadingTime = data['config']['loadingTime'];
-    config.questionTime = data['config']['questionTime'];
+    config.loadingTime = configData['loadingTime'];
+    config.questionTime = configData['questionTime'];
     this.config = config;
   }
 }

--- a/pupil-spa/src/app/storage.service.spec.ts
+++ b/pupil-spa/src/app/storage.service.spec.ts
@@ -56,7 +56,7 @@ describe('StorageService', () => {
     });
 
     it('returns item when key provided and item exists', () => {
-      const key = 'answer';
+      const key = 'answers';
       const value = { getItem: 'getItem_Value'};
       localStorage.setItem(key, JSON.stringify(value));
 
@@ -67,7 +67,7 @@ describe('StorageService', () => {
     });
 
     it('returns null when key provided and item does not exist', () => {
-      const key = 'answer';
+      const key = 'answers';
       const value = 'getItem_Value';
 
       const data = service.getItem(key);
@@ -92,7 +92,7 @@ describe('StorageService', () => {
 
     it('removes item when key provided and item exists', () => {
       spyOn(localStorage, 'removeItem');
-      const removeItemKey = 'answer';
+      const removeItemKey = 'answers';
 
       service.removeItem(removeItemKey);
 

--- a/pupil-spa/src/app/storage.service.ts
+++ b/pupil-spa/src/app/storage.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Answer } from './answer.service';
 
-export type StorageKey = 'answers' | 'inputs' | 'session' | 'audit' | 'questions';
+export type StorageKey = 'answers' | 'inputs' | 'session' |
+'audit' | 'questions' | 'config';
 
 @Injectable()
 export class StorageService {
 
-  setItem(key, value: Object | Array<Object>): void {
+  setItem(key: StorageKey, value: Object | Array<Object>): void {
 
     if (!key) {
       throw new Error('key is required');
@@ -14,14 +15,14 @@ export class StorageService {
     localStorage.setItem(key, JSON.stringify(value));
   }
 
-  getItem(key): any {
+  getItem(key: StorageKey): any {
     if (!key) {
       throw new Error('key is required');
     }
     return JSON.parse(localStorage.getItem(key));
   }
 
-  removeItem(key): void {
+  removeItem(key: StorageKey): void {
     if (!key) {
       throw new Error('key is required');
     }


### PR DESCRIPTION
created Union Type called StorageKey which narrows the keys used in the storage service to those which reflect each storage entity (questions, config, session etc...)

refactored question service and spec to accommodate this as tests were failing.