### PR TITLE
Fix data population errors to redirect to successful login page

### DIFF
--- a/pupil-spa/src/app/login-success/login-success.component.spec.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.spec.ts
@@ -3,6 +3,7 @@ import {Router} from '@angular/router';
 
 import { LoginSuccessComponent } from './login-success.component';
 import * as responseMock from '../login.response.mock.json';
+import { StorageService } from '../storage.service';
 
 describe('LoginSuccessComponent', () => {
   let component: LoginSuccessComponent;
@@ -10,30 +11,31 @@ describe('LoginSuccessComponent', () => {
   let store: {};
   let mockRouter;
 
-
-  beforeEach(async(() => {
+  beforeEach(() => {
     mockRouter = {
       navigate: jasmine.createSpy('navigate')
     };
 
-    TestBed.configureTestingModule({
+    const injector = TestBed.configureTestingModule({
       declarations: [ LoginSuccessComponent ],
       providers: [
-        { provide: Router, useValue: mockRouter }
+        { provide: Router, useValue: mockRouter },
+        StorageService
       ]
     })
-    .compileComponents();
+    const storageService = injector.get(StorageService);
+    injector.compileComponents();
 
-    spyOn(localStorage, 'getItem').and.callFake(function (key) {
+    spyOn(storageService, 'getItem').and.callFake(function (key) {
       return JSON.stringify(responseMock);
     });
-    spyOn(localStorage, 'setItem').and.callFake(function (key, value) {
+    spyOn(storageService, 'setItem').and.callFake(function (key, value) {
       return store[key] = value + '';
     });
-    spyOn(localStorage, 'clear').and.callFake(function () {
+    spyOn(storageService, 'clear').and.callFake(function () {
       store = {};
     });
-  }));
+  });
 
   beforeEach(() => {
     fixture = TestBed.createComponent(LoginSuccessComponent);

--- a/pupil-spa/src/app/login-success/login-success.component.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.ts
@@ -2,6 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { Pupil } from '../pupil';
 import { School } from '../school';
 import { Router } from '@angular/router';
+import { StorageService } from "../storage.service";
 
 @Component({
   selector: 'app-login-success',
@@ -13,13 +14,14 @@ export class LoginSuccessComponent implements OnInit {
   pupil: Pupil;
   school: School;
 
-  constructor(private router: Router) {
-    const data = JSON.parse(localStorage.getItem('data'));
+  constructor(private router: Router, private storageService: StorageService) {
+    const pupilData = storageService.getItem('pupil');
+    const schoolData = storageService.getItem('school');
     this.pupil = new Pupil;
-    this.pupil.firstName = data['pupil'].firstName;
-    this.pupil.lastName = data['pupil'].lastName;
+    this.pupil.firstName = pupilData.firstName;
+    this.pupil.lastName = pupilData.lastName;
     this.school = new School;
-    this.school.name = data['school'].name;
+    this.school.name = schoolData.name;
   }
 
   ngOnInit() {

--- a/pupil-spa/src/app/storage.service.ts
+++ b/pupil-spa/src/app/storage.service.ts
@@ -1,8 +1,7 @@
 import { Injectable } from '@angular/core';
-import { Answer } from './answer.service';
 
 export type StorageKey = 'answers' | 'inputs' | 'session' |
-'audit' | 'questions' | 'config';
+'audit' | 'questions' | 'config' | 'pupil' | 'school';
 
 @Injectable()
 export class StorageService {

--- a/pupil-spa/src/app/user.service.spec.ts
+++ b/pupil-spa/src/app/user.service.spec.ts
@@ -18,7 +18,7 @@ const shouldNotExecute = () => {
 let userService: UserService;
 let storageService: StorageService;
 let mockBackend: MockBackend;
-const sessionDataKey = 'session';
+const pupilDataKey = 'pupil';
 const questionsDataKey = 'questions';
 const configDataKey = 'config';
 
@@ -56,7 +56,7 @@ describe('UserService', () => {
 
       userService.login('abc12345', '9999a').then(() => {
         expect(storageService.setItem)
-          .toHaveBeenCalledWith(sessionDataKey, mockLoginResponseBody[sessionDataKey]);
+          .toHaveBeenCalledWith(pupilDataKey, mockLoginResponseBody[pupilDataKey]);
         expect(storageService.setItem)
           .toHaveBeenCalledWith(questionsDataKey, mockLoginResponseBody[questionsDataKey]);
         expect(storageService.setItem)

--- a/pupil-spa/src/app/user.service.ts
+++ b/pupil-spa/src/app/user.service.ts
@@ -5,6 +5,8 @@ import { StorageService } from './storage.service';
 const sessionDataKey = 'session';
 const questionsDataKey = 'questions';
 const configDataKey = 'config';
+const pupilDataKey = 'pupil';
+const schoolDataKey = 'school';
 
 @Injectable()
 export class UserService {
@@ -33,9 +35,12 @@ export class UserService {
           }
           const data = response.json();
           this.loggedIn = true;
-          this.storageService.setItem(sessionDataKey, data[sessionDataKey]);
+          // TODO: fetch session object when it's implemented in the API(?)
+          // this.storageService.setItem(sessionDataKey, data[sessionDataKey]);
           this.storageService.setItem(questionsDataKey, data[questionsDataKey]);
           this.storageService.setItem(configDataKey, data[configDataKey]);
+          this.storageService.setItem(pupilDataKey, data[pupilDataKey]);
+          this.storageService.setItem(schoolDataKey, data[schoolDataKey]);
           resolve();
         },
         (err) => {


### PR DESCRIPTION
@jon-shipley @GuyHarwood Keep in mind session always comes as undefined as it's not part of the api's response payload.