### PR TITLE
npm postinstall script not firing on container image build

### DIFF
--- a/pupil-spa/Dockerfile
+++ b/pupil-spa/Dockerfile
@@ -12,6 +12,8 @@ WORKDIR /ng-app
 
 COPY . .
 
+RUN npm run postinstall
+
 ## Build the angular app in production mode and store the artifacts in dist folder
 # RUN $(npm bin)/ng build --prod
 RUN $(npm bin)/ng build


### PR DESCRIPTION
postinstall called explicitly to ensure govuk assets are copied into intermediary build container