### PR TITLE
revert code that cleared storage when loading login component.

### DIFF
--- a/pupil-spa/src/app/login/login.component.spec.ts
+++ b/pupil-spa/src/app/login/login.component.spec.ts
@@ -5,7 +5,6 @@ import { UserService } from '../user.service';
 import { LoginComponent } from './login.component';
 import { QuestionService } from '../question.service';
 import { QuestionServiceMock } from '../question.service.mock';
-import { StorageService } from "../storage.service";
 
 describe('LoginComponent', () => {
   let component: LoginComponent;
@@ -14,7 +13,6 @@ describe('LoginComponent', () => {
   let mockUserService;
   let promiseHelper;
   let mockQuestionService = new QuestionServiceMock();
-  let storageService: StorageService;
 
   beforeEach(async(() => {
     mockRouter = {
@@ -37,32 +35,24 @@ describe('LoginComponent', () => {
     spyOn(mockUserService, 'login').and.returnValue(loginPromise);
 
     TestBed.configureTestingModule({
-      declarations: [ LoginComponent ],
+      declarations: [LoginComponent],
       providers: [
         { provide: UserService, useValue: mockUserService },
         { provide: Router, useValue: mockRouter },
-        { provide: QuestionService, useValue: mockQuestionService },
-        StorageService
+        { provide: QuestionService, useValue: mockQuestionService }
       ]
     }).compileComponents();
 
   }));
 
   beforeEach(() => {
-    storageService = TestBed.get(StorageService);
-    spyOn(storageService, 'clear');
     fixture = TestBed.createComponent(LoginComponent);
     fixture.detectChanges();
     component = fixture.componentInstance;
-
   });
 
   it('should be created', () => {
     expect(component).toBeTruthy();
-  });
-
-  it('should clear storageService when initialised', () => {
-    expect(storageService.clear).toHaveBeenCalledTimes(1);
   });
 
   it('should render schoolPin and pupil pin input boxes', () => {
@@ -80,7 +70,7 @@ describe('LoginComponent', () => {
     it('should redirect to success page given a valid schoolPin and pupilPin', async () => {
       component.onSubmit('goodPin', 'goodPin');
       fixture.whenStable().then(() => {
-        expect(mockRouter.navigate).toHaveBeenCalledWith([ 'sign-in-success' ]);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['sign-in-success']);
       });
     });
 
@@ -88,7 +78,7 @@ describe('LoginComponent', () => {
       component.onSubmit('goodPin', 'goodPin');
       component.onSubmit('goodPin', 'goodPin');
       fixture.whenStable().then(() => {
-        expect(mockRouter.navigate).toHaveBeenCalledWith([ 'sign-in-success' ]);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['sign-in-success']);
         expect(mockUserService.login).toHaveBeenCalledTimes(1);
       });
     });
@@ -103,7 +93,7 @@ describe('LoginComponent', () => {
     it('redirects to an error page when the login is rejected', async () => {
       component.onSubmit('badPin', 'badPin');
       fixture.whenStable().then(() => {
-        expect(mockRouter.navigate).toHaveBeenCalledWith([ 'sign-in-failure' ]);
+        expect(mockRouter.navigate).toHaveBeenCalledWith(['sign-in-failure']);
       });
     });
   });

--- a/pupil-spa/src/app/login/login.component.ts
+++ b/pupil-spa/src/app/login/login.component.ts
@@ -3,7 +3,6 @@ import { Router } from '@angular/router';
 
 import { UserService } from '../user.service';
 import { QuestionService } from '../question.service';
-import { StorageService } from '../storage.service';
 
 @Component({
   selector: 'app-login',
@@ -17,12 +16,10 @@ export class LoginComponent implements OnInit {
   constructor(
     private userService: UserService,
     private router: Router,
-    private questionService: QuestionService,
-    private storageService: StorageService
+    private questionService: QuestionService
   ) { }
 
   ngOnInit() {
-    this.storageService.clear();
     this.submitted = false;
   }
 

--- a/pupil-spa/test/features/login_page.feature
+++ b/pupil-spa/test/features/login_page.feature
@@ -52,11 +52,6 @@ Feature: Login page
     Given I have logged in
     Then local storage should be populated with questions and pupil metadata
 
-  @wip
-  Scenario: Local storage is cleared upon loading of the login page
-    Given I am on the sign in page
-    Then local storage should be cleared
-
   Scenario: Local storage is cleared when I have logged in but I return to login page as details are not correct
     Given I have logged in
     But I have chosen that the details are not correct


### PR DESCRIPTION
we should only clear storage on logout, currently.

next sprint includes work to time out the session.