### PR TITLE
Integrate Audit Service calls

### DIFF
--- a/pupil-spa/karma.conf.js
+++ b/pupil-spa/karma.conf.js
@@ -27,7 +27,7 @@ module.exports = function (config) {
     colors: true,
     logLevel: config.LOG_INFO,
     autoWatch: true,
-    browsers: ['ChromeHeadless'],
+    browsers: ['Chrome'],
     singleRun: false,
     customLaunchers: {
       Chrome_with_debugging: {

--- a/pupil-spa/src/app/audit.service.mock.ts
+++ b/pupil-spa/src/app/audit.service.mock.ts
@@ -1,0 +1,8 @@
+import { Injectable } from '@angular/core';
+import { AuditService } from './audit.service';
+import { AuditEntry, AuditEntryType } from './auditEntry';
+
+@Injectable()
+export class AuditServiceMock {
+  addEntry(auditEntry: AuditEntry): void { }
+}

--- a/pupil-spa/src/app/audit.service.mock.ts
+++ b/pupil-spa/src/app/audit.service.mock.ts
@@ -4,5 +4,6 @@ import { AuditEntry, AuditEntryType } from './auditEntry';
 
 @Injectable()
 export class AuditServiceMock {
-  addEntry(auditEntry: AuditEntry): void { }
+  addEntry(auditEntry: AuditEntry): void {
+   }
 }

--- a/pupil-spa/src/app/audit.service.spec.ts
+++ b/pupil-spa/src/app/audit.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { StorageServiceMock } from './storage.service.mock';
 import { AuditService } from './audit.service';
 import { StorageService } from './storage.service';
-import { AuditEntry, AuditEntryType, QuestionRenderedAuditEntry } from './auditEntry';
+import { AuditEntry, AuditEntryType, QuestionRendered, CheckStarted, QuestionAnswered } from './auditEntry';
 
 let service: AuditService;
 let mockStorageService: StorageServiceMock;
@@ -28,14 +28,14 @@ describe('AuditService', () => {
     it('should add entry using audit key to storageService', () => {
       spyOn(mockStorageService, 'setItem');
 
-      const entry = new QuestionRenderedAuditEntry();
+      const entry = new QuestionRendered();
       service.addEntry(entry);
 
       expect(mockStorageService.setItem).toHaveBeenCalledWith('audit', [entry]);
     });
 
     it('should add as one item array if no existing entries', () => {
-      const entry = new AuditEntry('CheckStarted', new Date());
+      const entry = new CheckStarted();
       let entries = new Array<AuditEntry>();
 
       spyOn(mockStorageService, 'getItem').and.callFake(() => {
@@ -55,9 +55,9 @@ describe('AuditService', () => {
     });
 
     it('should append new entries, preserve existing ones', () => {
-      const firstEntry = new AuditEntry('PauseRendered', new Date(), { foo: 'bar' });
-      const secondEntry = new AuditEntry('CheckStarted', new Date());
-      const thirdEntry = new AuditEntry('QuestionRendered', new Date());
+      const firstEntry = new CheckStarted({ foo: 'bar' });
+      const secondEntry = new QuestionRendered();
+      const thirdEntry = new QuestionAnswered();
       const expectedAuditEntries = new Array<AuditEntry>(firstEntry, secondEntry, thirdEntry);
       let actualAuditEntries = new Array<AuditEntry>();
 

--- a/pupil-spa/src/app/audit.service.spec.ts
+++ b/pupil-spa/src/app/audit.service.spec.ts
@@ -2,7 +2,7 @@ import { TestBed, inject } from '@angular/core/testing';
 import { StorageServiceMock } from './storage.service.mock';
 import { AuditService } from './audit.service';
 import { StorageService } from './storage.service';
-import { AuditEntry, AuditEntryType } from './auditEntry';
+import { AuditEntry, AuditEntryType, QuestionRenderedAuditEntry } from './auditEntry';
 
 let service: AuditService;
 let mockStorageService: StorageServiceMock;
@@ -28,7 +28,7 @@ describe('AuditService', () => {
     it('should add entry using audit key to storageService', () => {
       spyOn(mockStorageService, 'setItem');
 
-      const entry = new AuditEntry('QuestionRendered', new Date());
+      const entry = new QuestionRenderedAuditEntry();
       service.addEntry(entry);
 
       expect(mockStorageService.setItem).toHaveBeenCalledWith('audit', [entry]);

--- a/pupil-spa/src/app/audit.service.ts
+++ b/pupil-spa/src/app/audit.service.ts
@@ -1,16 +1,16 @@
 import { Injectable } from '@angular/core';
 import { StorageService } from './storage.service';
-import { AuditEntry, AuditEntryType } from './auditEntry';
+import  * as AuditTypes from './auditEntry';
 
 @Injectable()
 export class AuditService {
 
   constructor(private storageService: StorageService) { }
 
-  addEntry(auditEntry: AuditEntry): void {
-    let existingEntries = this.storageService.getItem('audit') as Array<AuditEntry>;
+  addEntry(auditEntry: AuditTypes.CheckStarted | AuditTypes.QuestionRendered | AuditTypes.PauseRendered | AuditTypes.QuestionAnswered): void {
+    let existingEntries = this.storageService.getItem('audit') as Array<AuditTypes.AuditEntry>;
     if (!existingEntries) {
-      existingEntries = new Array<AuditEntry>();
+      existingEntries = new Array<AuditTypes.AuditEntry>();
     }
     existingEntries.push(auditEntry);
     this.storageService.setItem('audit', existingEntries);

--- a/pupil-spa/src/app/auditEntry.ts
+++ b/pupil-spa/src/app/auditEntry.ts
@@ -7,3 +7,15 @@ export class AuditEntry {
     public clientTimestamp: Date,
     public data?: object) { }
 }
+
+export class QuestionRenderedAuditEntry extends AuditEntry {
+  constructor(){
+    super('QuestionRendered', new Date());
+  }
+}
+
+export class CheckStartedAuditEntry extends AuditEntry {
+  constructor(){
+    super('CheckStarted', new Date());
+  }
+}

--- a/pupil-spa/src/app/auditEntry.ts
+++ b/pupil-spa/src/app/auditEntry.ts
@@ -1,6 +1,6 @@
-export type AuditEntryType = 'CheckStarted' | 'QuestionRendered' | 'QuestionAnswered' | 'PauseRendered' | 'UserInput';
+export type AuditEntryType = 'CheckStarted' | 'QuestionRendered' | 'QuestionAnswered' | 'PauseRendered';
 
-export class AuditEntry {
+export abstract class AuditEntry {
 
   constructor(
     public type: AuditEntryType,
@@ -8,14 +8,26 @@ export class AuditEntry {
     public data?: object) { }
 }
 
-export class QuestionRenderedAuditEntry extends AuditEntry {
-  constructor(){
-    super('QuestionRendered', new Date());
+export class QuestionRendered extends AuditEntry {
+  constructor(data?: any) {
+    super('QuestionRendered', new Date(), data);
   }
 }
 
-export class CheckStartedAuditEntry extends AuditEntry {
-  constructor(){
-    super('CheckStarted', new Date());
+export class CheckStarted extends AuditEntry {
+  constructor(data?: any) {
+    super('CheckStarted', new Date(), data);
+  }
+}
+
+export class QuestionAnswered extends AuditEntry {
+  constructor(data?: any) {
+    super('QuestionAnswered', new Date(), data);
+  }
+}
+
+export class PauseRendered extends AuditEntry {
+  constructor(data?: any) {
+    super('PauseRendered', new Date(), data);
   }
 }

--- a/pupil-spa/src/app/question/question.component.spec.ts
+++ b/pupil-spa/src/app/question/question.component.spec.ts
@@ -1,14 +1,21 @@
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { QuestionComponent } from './question.component';
+import { AuditService } from "../audit.service";
+import { AuditServiceMock } from "../audit.service.mock";
+import { QuestionRenderedAuditEntry } from "../auditEntry";
 
 describe('QuestionComponent', () => {
   let component: QuestionComponent;
   let fixture: ComponentFixture<QuestionComponent>;
+  let auditServiceMock = new AuditServiceMock();
 
   beforeEach(async(() => {
     TestBed.configureTestingModule({
-      declarations: [ QuestionComponent ]
+      declarations: [QuestionComponent],
+      providers: [
+        { provide: AuditService, useValue: auditServiceMock }
+      ]
     })
       .compileComponents();
   }));
@@ -105,6 +112,18 @@ describe('QuestionComponent', () => {
       expect(component.handleKeyboardEvent).toHaveBeenCalledTimes(1);
       expect(component.handleKeyboardEvent).toHaveBeenCalledWith(event1);
       // expect(component.answer).toBe('1');
+    });
+  });
+
+  describe('auditing', () => {
+    beforeEach(() => {
+      spyOn(auditServiceMock, 'addEntry');
+    });
+    it('adds audit entry on question rendered', () => {
+      fixture.whenRenderingDone().then(() => {
+        // expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
+        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionRenderedAuditEntry())
+      });
     });
   });
 

--- a/pupil-spa/src/app/question/question.component.spec.ts
+++ b/pupil-spa/src/app/question/question.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { QuestionComponent } from './question.component';
 import { AuditService } from "../audit.service";
 import { AuditServiceMock } from "../audit.service.mock";
-import { QuestionRenderedAuditEntry } from "../auditEntry";
+import { QuestionRendered, QuestionAnswered } from "../auditEntry";
 
 describe('QuestionComponent', () => {
   let component: QuestionComponent;
@@ -117,14 +117,23 @@ describe('QuestionComponent', () => {
 
   describe('auditing', () => {
     beforeEach(() => {
-      spyOn(auditServiceMock, 'addEntry');
-    });
-    it('adds audit entry on question rendered', () => {
-      fixture.whenRenderingDone().then(() => {
-        // expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
-        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionRenderedAuditEntry())
+      spyOn(auditServiceMock, 'addEntry').and.callFake((entry) => {
+        console.log('addEntry called with:', entry);
       });
     });
+    it('adds audit entry on question rendered', async(() => {
+      fixture.whenRenderingDone().then(() => {
+        expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
+        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionRendered());
+      });
+    }));
+
+    it('adds audit entry on answer submitted', async(() => {
+      fixture.whenRenderingDone().then(() => {
+        expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
+        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionAnswered());
+      });
+    }));
   });
 
 });

--- a/pupil-spa/src/app/question/question.component.spec.ts
+++ b/pupil-spa/src/app/question/question.component.spec.ts
@@ -3,7 +3,7 @@ import { async, ComponentFixture, TestBed } from '@angular/core/testing';
 import { QuestionComponent } from './question.component';
 import { AuditService } from "../audit.service";
 import { AuditServiceMock } from "../audit.service.mock";
-import { QuestionRendered, QuestionAnswered } from "../auditEntry";
+import { QuestionRendered, QuestionAnswered, AuditEntry } from "../auditEntry";
 
 describe('QuestionComponent', () => {
   let component: QuestionComponent;
@@ -25,7 +25,7 @@ describe('QuestionComponent', () => {
     component = fixture.componentInstance;
     fixture.detectChanges();
     // prevent Timeout's being set
-    spyOn(component, 'ngAfterViewInit').and.returnValue(null);
+    //spyOn(component, 'ngAfterViewInit').and.returnValue(null);
   });
 
   it('should be created', () => {
@@ -115,23 +115,28 @@ describe('QuestionComponent', () => {
     });
   });
 
-  describe('auditing', () => {
+  describe('audit entry', () => {
+    let auditEntryInserted: AuditEntry;
     beforeEach(() => {
-      spyOn(auditServiceMock, 'addEntry').and.callFake((entry) => {
-        console.log('addEntry called with:', entry);
+      let auditService = fixture.debugElement.injector.get(AuditService);
+      spyOn(auditService, 'addEntry').and.callFake((entry) => {
+        auditEntryInserted = entry;
       });
     });
-    it('adds audit entry on question rendered', async(() => {
+    it('is added on question rendered', async(() => {
       fixture.whenRenderingDone().then(() => {
+        component.ngAfterViewInit();
         expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
-        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionRendered());
+        expect(auditEntryInserted instanceof QuestionRendered).toBeTruthy();
       });
     }));
 
-    it('adds audit entry on answer submitted', async(() => {
+    it('is added on answer submitted', async(() => {
       fixture.whenRenderingDone().then(() => {
+        spyOn(component,'answerIsLongEnoughToManuallySubmit').and.returnValue(true);
+        component.onSubmit();
         expect(auditServiceMock.addEntry).toHaveBeenCalledTimes(1);
-        expect(auditServiceMock.addEntry).toHaveBeenCalledWith(new QuestionAnswered());
+        expect(auditEntryInserted instanceof QuestionAnswered).toBeTruthy();
       });
     }));
   });

--- a/pupil-spa/src/app/question/question.component.ts
+++ b/pupil-spa/src/app/question/question.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, AfterViewInit, Input, Output, EventEmitter, HostListener } from '@angular/core';
 import { AuditService } from "../audit.service";
-import { QuestionRenderedAuditEntry } from "../auditEntry";
+import { QuestionRendered } from "../auditEntry";
 
 @Component({
   selector: 'app-question',
@@ -80,7 +80,7 @@ export class QuestionComponent implements OnInit, AfterViewInit {
    * Start the timer when the view is ready.
    */
   ngAfterViewInit() {
-    this.auditService.addEntry(new QuestionRenderedAuditEntry());
+    this.auditService.addEntry(new QuestionRendered());
     this.timeout = setTimeout(() => {
       this.sendTimeoutEvent();
     }, this.questionTimeoutSecs * 1000);
@@ -131,6 +131,7 @@ export class QuestionComponent implements OnInit, AfterViewInit {
       clearTimeout(this.timeout);
     }
     // console.log(`submitting answer ${this.answer}`);
+
     this.manualSubmitEvent.emit(this.answer);
     this.submitted = true;
     return true;

--- a/pupil-spa/src/app/question/question.component.ts
+++ b/pupil-spa/src/app/question/question.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit, AfterViewInit, Input, Output, EventEmitter, HostListener } from '@angular/core';
+import { AuditService } from "../audit.service";
+import { QuestionRenderedAuditEntry } from "../auditEntry";
 
 @Component({
   selector: 'app-question',
@@ -6,6 +8,10 @@ import { Component, OnInit, AfterViewInit, Input, Output, EventEmitter, HostList
   styleUrls: [ './question.component.css' ]
 })
 export class QuestionComponent implements OnInit, AfterViewInit {
+
+  constructor(private auditService: AuditService) {
+  }
+
   @Input()
   public factor1 = 0;
 
@@ -67,9 +73,6 @@ export class QuestionComponent implements OnInit, AfterViewInit {
     return false;
   }
 
-  constructor() {
-  }
-
   ngOnInit() {
   }
 
@@ -77,6 +80,7 @@ export class QuestionComponent implements OnInit, AfterViewInit {
    * Start the timer when the view is ready.
    */
   ngAfterViewInit() {
+    this.auditService.addEntry(new QuestionRenderedAuditEntry());
     this.timeout = setTimeout(() => {
       this.sendTimeoutEvent();
     }, this.questionTimeoutSecs * 1000);

--- a/pupil-spa/src/app/question/question.component.ts
+++ b/pupil-spa/src/app/question/question.component.ts
@@ -1,11 +1,11 @@
 import { Component, OnInit, AfterViewInit, Input, Output, EventEmitter, HostListener } from '@angular/core';
 import { AuditService } from "../audit.service";
-import { QuestionRendered } from "../auditEntry";
+import { QuestionRendered, QuestionAnswered } from "../auditEntry";
 
 @Component({
   selector: 'app-question',
   templateUrl: './question.component.html',
-  styleUrls: [ './question.component.css' ]
+  styleUrls: ['./question.component.css']
 })
 export class QuestionComponent implements OnInit, AfterViewInit {
 
@@ -31,7 +31,7 @@ export class QuestionComponent implements OnInit, AfterViewInit {
   private submitted = false;
   private timeout;
 
-  @HostListener('document:keydown', [ '$event' ])
+  @HostListener('document:keydown', ['$event'])
   handleKeyboardEvent(event: KeyboardEvent) {
     // console.log(`question.component: handleKeyboardEvent() called: key: ${event.key} keyCode: ${event.keyCode}`);
     const key = event.key;
@@ -131,7 +131,7 @@ export class QuestionComponent implements OnInit, AfterViewInit {
       clearTimeout(this.timeout);
     }
     // console.log(`submitting answer ${this.answer}`);
-
+    this.auditService.addEntry(new QuestionAnswered());
     this.manualSubmitEvent.emit(this.answer);
     this.submitted = true;
     return true;


### PR DESCRIPTION
# WIP DO NOT MERGE

This PR is merely to enable in-context discussion on the code itself to aid resolution.

Problem:  assertions on the calls to `auditService.addEntry` by the component fail, stating it was called zero times.  It is in fact called by the component during the test run.

The only way i have managed to get the assertion to pass is to comment out the fake created for component.ngAfterViewInit, which was explicitly added by @jon-shipley to avoid the timeout calls.

See inline comments added below for more info.