### PR TITLE
Disable double-tap zooms on iPad 

### DIFF
--- a/pupil-spa/src/app/check/check.component.ts
+++ b/pupil-spa/src/app/check/check.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, HostListener } from '@angular/core';
 
 import { QuestionService } from '../question.service';
 import { Question } from '../question.model';
@@ -23,6 +23,14 @@ export class CheckComponent implements OnInit {
     this.totalNumberOfQuestions = this.questionService.getNumberOfQuestions();
     this.question = this.questionService.getQuestion(this.questionNumber);
     this.config = this.questionService.getConfig();
+  }
+
+  @HostListener('document:touchend', [ '$event' ])
+  handleTouchEndEvent() {
+    // IMPORTANT: Prevent double-tap zoom on Ipad
+    event.preventDefault();
+    event.target.dispatchEvent(new Event('click'));
+    return false;
   }
 
   ngOnInit() {


### PR DESCRIPTION
Present double-tap from zooming in when performing the check on an iPad.  This is likely to occur when entering repeated digits.

Just calling event.preventDefault is not enough as this will also disable the virtual keypad.  Triggering the click event by calling `event.target.dispatchEvent(new Event('click'));` adds normal functionality back in.