### PR TITLE
Further unit tests

### DIFF
--- a/pupil-spa/src/app/feedback/feedback.component.spec.ts
+++ b/pupil-spa/src/app/feedback/feedback.component.spec.ts
@@ -116,4 +116,28 @@ describe('FeedbackComponent', () => {
       expect(component.onSelectionChange).toHaveBeenCalledWith('satisfactionRating', {id: 2, value: 'Easy'});
     });
   });
+
+  it('should onSubmit be called when clicking button and there are no errors', () => {
+    component['errorInputType'] = false;
+    component['errorSatisfactionRating'] = false;
+
+    fixture.detectChanges();
+    const compiled = fixture.debugElement.nativeElement;
+    compiled.querySelector('input[type=submit]').click();
+    fixture.whenStable().then(() => {
+      expect(component.onSubmit).toHaveBeenCalledTimes(1);
+      expect(this.feedbackService.postFeedback).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('should onSubmit NOT be called when clicking button and there are errors', () => {
+    component['errorInputType'] = true;
+    component['errorSatisfactionRating'] = true;
+    fixture.detectChanges();
+    const compiled = fixture.debugElement.nativeElement;
+    compiled.querySelector('input[type=submit]').click();
+    fixture.whenStable().then(() => {
+      expect(component.onSubmit).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/pupil-spa/src/app/phase-banner/phase-banner.component.spec.ts
+++ b/pupil-spa/src/app/phase-banner/phase-banner.component.spec.ts
@@ -41,11 +41,20 @@ describe('PhaseBannerComponent', () => {
     );
   });
 
-  xit('should have link to the feedback page', () => {
+  it('should have link to the feedback page if showFeedback is true', () => {
+    component['showFeedback'] = true;
+    fixture.detectChanges();
     const compiled = fixture.debugElement.nativeElement;
     expect(compiled.querySelector('.phase-banner span a').textContent).toMatch(
       /feedback/
     );
+    expect(compiled.querySelector('.phase-banner span a').getAttribute('routerLink')).toMatch(
+      '/feedback'
+    );
   });
-/* TODO: check feedback link is correct (once we know the path) */
+
+  it('should not have link to the feedback by default', () => {
+    const compiled = fixture.debugElement.nativeElement;
+    expect(compiled.querySelector('.phase-banner span a')).toBeNull();
+  });
 });


### PR DESCRIPTION
Further unit test coverage for components:
- 'phase-banner'
- 'feedback'