### PR TITLE
Feature/16612 pupil content changes

### DIFF
--- a/admin/controllers/questions.js
+++ b/admin/controllers/questions.js
@@ -25,10 +25,7 @@ const getQuestions = async (req, res) => {
     return apiResponse.unauthorised(res)
   }
 
-  const pupilData = {
-    firstName: pupil.foreName,
-    lastName: pupil.lastName
-  }
+  const pupilData = pupilAuthenticationService.getPupilDataForSpa(pupil)
 
   const schoolData = {
     id: pupil.school._id,

--- a/admin/controllers/questions.js
+++ b/admin/controllers/questions.js
@@ -67,7 +67,7 @@ const getQuestions = async (req, res) => {
     pupil: pupilData,
     school: schoolData,
     config,
-    access_token: token
+    access_token: token.token
   }
   // console.log('response', responseData)
 

--- a/admin/package.json
+++ b/admin/package.json
@@ -13,7 +13,7 @@
     "sasswatch": "gulp watch"
   },
   "engines": {
-    "node": "8.4.0"
+    "node": ">= 8.4"
   },
   "dependencies": {
     "applicationinsights": "^0.22.0",

--- a/admin/services/data-access/pupil.data.service.js
+++ b/admin/services/data-access/pupil.data.service.js
@@ -1,0 +1,31 @@
+'use strict'
+
+const Pupil = require('../../models/pupil')
+const pupilDataService = {}
+
+/**
+ * Find a single pupil by criteria in `options`
+ * @param options
+ * @return {Promise.<{Object}>}
+ */
+pupilDataService.findOne = async function (options) {
+  const p = await Pupil.findOne(options).populate('school').lean().exec()
+  return p
+}
+
+/**
+ * Update a single object with the new fields from `doc`
+ * @param {string} id Object._id
+ * @param {Object} doc Document to pass to mongo
+ * @return {Promise}
+ */
+pupilDataService.update = async function (id, doc) {
+  return new Promise((resolve, reject) => {
+    Pupil.updateOne({_id: id}, doc, (error) => {
+      if (error) { return reject(error) }
+      resolve(null)
+    })
+  })
+}
+
+module.exports = pupilDataService

--- a/admin/services/data-access/school.data.service.js
+++ b/admin/services/data-access/school.data.service.js
@@ -1,0 +1,12 @@
+'ust strict'
+
+const School = require('../../models/school')
+
+const schoolDataService = {}
+
+schoolDataService.findOne = async function (options) {
+  const s = await School.findOne(options).lean().exec()
+  return s
+}
+
+module.exports = schoolDataService

--- a/admin/services/date.service.js
+++ b/admin/services/date.service.js
@@ -1,0 +1,17 @@
+'use strict'
+const moment = require('moment')
+
+const gdsFullFormat = 'D MMMM YYYY'
+const gdsShortFormat = 'D MMM YYYY'
+
+const dateService = {
+  formatFullGdsDate: (date) => {
+    return moment(date).format(gdsFullFormat)
+  },
+
+  formatShortGdsDate: (date) => {
+    return moment(date).format(gdsShortFormat)
+  }
+}
+
+module.exports = dateService

--- a/admin/services/jwt.service.js
+++ b/admin/services/jwt.service.js
@@ -50,7 +50,6 @@ const jwtService = {
     const decoded = jwt.decode(token)
 
     // Find the pupil in the subject to retrieve the secret
-    // const pupil = await Pupil.findOne(ObjectId(decoded.sub)).lean().exec()
     const pupil = await pupilDataService.findOne({_id: ObjectId(decoded.sub)})
 
     if (!pupil) {

--- a/admin/services/pupil-authentication.service.js
+++ b/admin/services/pupil-authentication.service.js
@@ -1,7 +1,7 @@
 'use strict'
-const School = require('../models/school')
-const Pupil = require('../models/pupil')
 const dateService = require('../services/date.service')
+const schoolDataService = require('../services/data-access/school.data.service')
+const pupilDataService = require('../services/data-access/pupil.data.service')
 
 const pupilAuthenticationService = {
   /**
@@ -11,16 +11,13 @@ const pupilAuthenticationService = {
    * @return {Promise.<Pupil>}
    */
   authenticate: async (pupilPin, schoolPin) => {
-    let school, pupil
-    // Until we determine the logic behind fetching the appropriate check form
-    // the pupil will receive the first one
-    school = await School.findOne({schoolPin: schoolPin}).lean().exec()
-    pupil = await Pupil.findOne({
+    const school = await schoolDataService.findOne({schoolPin: schoolPin})
+    const pupil = await pupilDataService.findOne({
       pin: pupilPin,
       school: school && school._id,
       pinExpired: false,
       hasAttended: false
-    }).populate('school').exec()
+    })
     if (!pupil || !school) {
       throw new Error('Authentication failure')
     }

--- a/admin/services/pupil-authentication.service.js
+++ b/admin/services/pupil-authentication.service.js
@@ -1,7 +1,7 @@
 'use strict'
-
 const School = require('../models/school')
 const Pupil = require('../models/pupil')
+const dateService = require('../services/date.service')
 
 const pupilAuthenticationService = {
   /**
@@ -25,6 +25,15 @@ const pupilAuthenticationService = {
       throw new Error('Authentication failure')
     }
     return pupil
+  },
+
+  getPupilDataForSpa: (pupil) => {
+    const pupilData = {
+      firstName: pupil.foreName,
+      lastName: pupil.lastName,
+      dob: dateService.formatFullGdsDate(pupil.dob)
+    }
+    return pupilData
   }
 }
 

--- a/admin/spec/mocks/mongoose-model-mock.js
+++ b/admin/spec/mocks/mongoose-model-mock.js
@@ -4,6 +4,7 @@ class MongooseModelMock {
   }
   findOne () { return this }
   lean () { return this }
+  updateOne () { return this.done() }
   exec () { return this.done() }
 }
 

--- a/admin/spec/mocks/pupil.js
+++ b/admin/spec/mocks/pupil.js
@@ -3,5 +3,6 @@ module.exports = {
   school: 9991001,
   foreName: 'Pupil',
   lastName: 'One',
-  pin: 'd55sg'
+  pin: 'd55sg',
+  dob: '2000-12-31 00:00:00'
 }

--- a/admin/spec/routes/questions.spec.js
+++ b/admin/spec/routes/questions.spec.js
@@ -16,6 +16,12 @@ const checkStartResponseMock = {
   checkForm: require('../mocks/checkform')
 }
 
+const getPupilDataFoSpaMock = {
+  firstName: 'Test',
+  lastName: 'User',
+  dob: '1 January 2000'
+}
+
 describe('Questions controller', () => {
   let goodReq, res
 
@@ -51,9 +57,13 @@ describe('Questions controller', () => {
     if (!options['check-start.service.startCheck']) {
       options['check-start.service.startCheck'] = function () { return Promise.resolve(checkStartResponseMock) }
     }
+    if (!options['pupil-authentication.service.getPupilDataForSpa']) {
+      options['pupil-authentication.service.getPupilDataForSpa'] = function () { return getPupilDataFoSpaMock }
+    }
     return proxyquire('../../controllers/questions', {
       '../services/pupil-authentication.service': {
-        authenticate: jasmine.createSpy().and.callFake(options['pupil-authentication.service.authenticate'])
+        authenticate: jasmine.createSpy().and.callFake(options['pupil-authentication.service.authenticate']),
+        getPupilDataForSpa: jasmine.createSpy().and.callFake(options['pupil-authentication.service.getPupilDataForSpa'])
       },
       '../services/config.service': {
         getConfig: jasmine.createSpy().and.callFake(options['config.service.getConfig'])
@@ -84,7 +94,7 @@ describe('Questions controller', () => {
       const data = JSON.parse(res._getData())
       expect(res.statusCode).toBe(200)
       expect(data.questions.length).toBe(20)
-      expect(data.pupil.firstName).toBe('Pupil')
+      expect(data.pupil.firstName).toBe('Test')
       expect(data.school.name).toBe('Example School One')
       expect(data.config.questionTime).toBe(6)
       done()

--- a/admin/spec/service/data-access/pupil.data.service.spec.js
+++ b/admin/spec/service/data-access/pupil.data.service.spec.js
@@ -1,0 +1,48 @@
+'use strict'
+/* global describe, beforeEach, afterEach, it, expect */
+
+const proxyquire = require('proxyquire').noCallThru()
+const sinon = require('sinon')
+require('sinon-mongoose')
+
+const Pupil = require('../../../models/pupil')
+const pupilMock = require('../../mocks/pupil')
+
+describe('pupil.data.service', () => {
+  let service, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => sandbox.restore())
+
+  describe('#findOne', () => {
+    let mock
+
+    beforeEach(() => {
+      mock = sinon.mock(Pupil).expects('findOne').chain('populate').chain('lean').chain('exec').resolves(pupilMock)
+      service = proxyquire('../../../services/data-access/pupil.data.service', {
+        '../../models/pupil': Pupil
+      })
+    })
+
+    it('calls the model', () => {
+      service.findOne({_id: 'some-id'})
+      expect(mock.verify()).toBe(true)
+    })
+  })
+
+  describe('#update', () => {
+    beforeEach(() => {
+      sinon.mock(Pupil).expects('updateOne').returns(pupilMock)
+      service = proxyquire('../../../services/data-access/pupil.data.service', {
+        '../../models/pupil': Pupil
+      })
+    })
+
+    it('has an update method', () => {
+      expect(typeof service.update).toBe('function')
+    })
+  })
+})

--- a/admin/spec/service/data-access/school.data.service.spec.js
+++ b/admin/spec/service/data-access/school.data.service.spec.js
@@ -1,0 +1,35 @@
+'use strict'
+/* global describe, beforeEach, afterEach, it, expect */
+
+const proxyquire = require('proxyquire').noCallThru()
+const sinon = require('sinon')
+require('sinon-mongoose')
+
+const School = require('../../../models/school')
+const schoolMock = require('../../mocks/school')
+
+describe('school.data.service', () => {
+  let service, sandbox
+
+  beforeEach(() => {
+    sandbox = sinon.sandbox.create()
+  })
+
+  afterEach(() => sandbox.restore())
+
+  describe('#findOne', () => {
+    let mock
+
+    beforeEach(() => {
+      mock = sinon.mock(School).expects('findOne').chain('lean').chain('exec').resolves(schoolMock)
+      service = proxyquire('../../../services/data-access/school.data.service', {
+        '../../models/school': School
+      })
+    })
+
+    it('calls the model', () => {
+      service.findOne({_id: 'some-id'})
+      expect(mock.verify()).toBe(true)
+    })
+  })
+})

--- a/admin/spec/service/date.service.spec.js
+++ b/admin/spec/service/date.service.spec.js
@@ -1,0 +1,20 @@
+'use strict'
+/* global describe it expect */
+
+const dateService = require('../../services/date.service')
+
+describe('date service', () => {
+  describe('#formatFullGDSdate', () => {
+    it('correctly formats a date', () => {
+      const date = new Date(2010, 11, 31, 14, 10, 0, 0)
+      expect(dateService.formatFullGdsDate(date)).toBe('31 December 2010')
+    })
+  })
+
+  describe('#formatShortGDSdate', () => {
+    it('correctly formats a date', () => {
+      const date = new Date(2010, 11, 31, 14, 10, 0, 0)
+      expect(dateService.formatShortGdsDate(date)).toBe('31 Dec 2010')
+    })
+  })
+})

--- a/admin/spec/service/jwt.service.spec.js
+++ b/admin/spec/service/jwt.service.spec.js
@@ -1,24 +1,20 @@
 'use strict'
-const sinon = require('sinon')
-require('sinon-mongoose')
+/* global beforeEach, afterEach, describe, it, expect, jasmine */
+
 const mongoose = require('mongoose')
 mongoose.Promise = global.Promise
 const jwt = require('jsonwebtoken')
 const proxyquire = require('proxyquire')
 const ObjectId = require('mongoose').Types.ObjectId
 
-const Pupil = require('../../models/pupil')
-
 let jwtService
-let sandbox
-
-/* global beforeEach, afterEach, describe, it, expect, spyOn */
+let pupilDataServiceUpdateSpy
 
 describe('JWT service', () => {
   let pupil
 
   beforeEach(() => {
-    pupil = new Pupil({
+    pupil = {
       _id: new mongoose.Types.ObjectId(),
       jwtSecret: undefined,
       // required pupil fields
@@ -27,30 +23,29 @@ describe('JWT service', () => {
       school: 9991999,
       lastName: 'Test',
       foreName: 'TestForename'
-    })
-    sandbox = sinon.sandbox.create()
-    spyOn(pupil, 'save').and.callFake(() => Promise.resolve(pupil))
+    }
   })
 
-  afterEach(() => {
-    sandbox.restore()
-  })
-
-  describe('creating a token', () => {
+  describe('#createToken', () => {
     beforeEach(() => {
-      jwtService = require('../../services/jwt.service')
+      pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () { return Promise.resolve() })
+      jwtService = proxyquire('../../services/jwt.service', {
+        './data-access/pupil.data.service': {
+          update: pupilDataServiceUpdateSpy
+        }
+      })
     })
 
     it('creates a token', async (done) => {
       const token = await jwtService.createToken(pupil)
-      expect(token).toBeTruthy()
-      expect(token.split('.').length).toBe(3)
+      expect(token.token).toBeTruthy()
+      expect(token.token.split('.').length).toBe(3)
       done()
     })
 
     it('the token details look correct', async (done) => {
       const token = await jwtService.createToken(pupil)
-      const decoded = jwt.verify(token, pupil.jwtSecret)
+      const decoded = jwt.verify(token.token, token.jwtSecret)
       expect(decoded).toBeTruthy()
       const expiry = Math.abs(decoded.exp - Math.round(Date.now() / 1000))
       expect(expiry - 3600 <= 1).toBe(true) // expect the expiry date to be 3600 seconds +- 1 second
@@ -62,7 +57,7 @@ describe('JWT service', () => {
     it('throws an error when the pupil object is missing', async (done) => {
       try {
         await jwtService.createToken()
-        done(new Error('Expected call to throw and it didn\'t'))
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Pupil is required')
         done()
@@ -72,9 +67,9 @@ describe('JWT service', () => {
     it('saves a new secret on the pupil', async (done) => {
       const token = await jwtService.createToken(pupil)
       expect(token).toBeTruthy()
-      expect(pupil.save).toHaveBeenCalled()
-      expect(pupil.jwtSecret).toBeTruthy()
-      expect(pupil.jwtSecret.length).toBe(64)
+      expect(pupilDataServiceUpdateSpy).toHaveBeenCalled()
+      expect(token.jwtSecret).toBeTruthy()
+      expect(token.jwtSecret.length).toBe(64)
       done()
     })
   })
@@ -83,7 +78,7 @@ describe('JWT service', () => {
     it('throws an error if the token is not provided', async (done) => {
       try {
         await jwtService.verify()
-        done(new Error('did not expect to be called'))
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Token is required')
         done()
@@ -91,37 +86,52 @@ describe('JWT service', () => {
     })
 
     describe('and the pupil is found', () => {
+      let pupilDataServiceFindOneSpy
       beforeEach(() => {
-        sandbox.mock(Pupil).expects('findOne').chain('lean').chain('exec').resolves(pupil)
+        pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () { return Promise.resolve() })
+        pupilDataServiceFindOneSpy = jasmine.createSpy().and.callFake(function () { return Promise.resolve(pupil) })
         jwtService = proxyquire('../../services/jwt.service', {
-          '../models/pupil': Pupil
+          './data-access/pupil.data.service': {
+            update: pupilDataServiceUpdateSpy,
+            findOne: pupilDataServiceFindOneSpy
+          }
         })
       })
 
       it('then it is able to decode a valid token', async (done) => {
         const token = await jwtService.createToken(pupil)
         try {
-          const isVerified = await jwtService.verify(token)
+          pupil.jwtSecret = token.jwtSecret
+          const isVerified = await jwtService.verify(token.token)
           expect(isVerified).toBe(true)
-          done()
         } catch (error) {
-          done('Not expected to get here')
+          expect(error).toBeFalsy()
         }
+        done()
       })
     })
 
     describe('and the pupil is NOT found', () => {
+      let pupilDataServiceFindOneSpy
       beforeEach(() => {
-        sandbox.mock(Pupil).expects('findOne').chain('lean').chain('exec').resolves(null)
+        pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve()
+        })
+        pupilDataServiceFindOneSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve(null)
+        })
         jwtService = proxyquire('../../services/jwt.service', {
-          '../models/pupil': Pupil
+          './data-access/pupil.data.service': {
+            update: pupilDataServiceUpdateSpy,
+            findOne: pupilDataServiceFindOneSpy
+          }
         })
       })
       it('then it throws an error', async (done) => {
         const token = await jwtService.createToken(pupil)
         try {
-          await jwtService.verify(token)
-          done('Not expected to get here')
+          await jwtService.verify(token.token)
+          expect('this').toBe('thrown')
         } catch (error) {
           expect(error.message).toBe('Subject not found')
           done()
@@ -130,12 +140,20 @@ describe('JWT service', () => {
     })
 
     describe('and the pupil has had the key revoked', () => {
+      let pupilDataServiceFindOneSpy
       beforeEach(() => {
-        const newPupil = JSON.parse(JSON.stringify(pupil))
-        newPupil.jwtSecret = undefined
-        sandbox.mock(Pupil).expects('findOne').chain('lean').chain('exec').resolves(newPupil)
+        pupil.jwtSecret = undefined
+        pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve()
+        })
+        pupilDataServiceFindOneSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve(pupil)
+        })
         jwtService = proxyquire('../../services/jwt.service', {
-          '../models/pupil': Pupil
+          './data-access/pupil.data.service': {
+            update: pupilDataServiceUpdateSpy,
+            findOne: pupilDataServiceFindOneSpy
+          }
         })
       })
       it('then it throws an error', async (done) => {
@@ -145,8 +163,8 @@ describe('JWT service', () => {
         // (as it is not a required property) so we get the sandbox to returned a cloned object that
         // definitely does not have a valid `jztSecret` property.
         try {
-          await jwtService.verify(token)
-          done('Not expected to get here')
+          await jwtService.verify(token.token)
+          expect('this').toBe('thrown')
         } catch (error) {
           expect(error.message).toBe('Error - missing secret')
           done()
@@ -154,19 +172,27 @@ describe('JWT service', () => {
       })
     })
     describe('and the pupil has an incorrect jwtSecret', () => {
+      let pupilDataServiceFindOneSpy
       beforeEach(() => {
-        const newPupil = JSON.parse(JSON.stringify(pupil))
-        newPupil.jwtSecret = 'incorrect secret'
-        sandbox.mock(Pupil).expects('findOne').chain('lean').chain('exec').resolves(newPupil)
+        pupil.jwtSecret = 'incorrect secret'
+        pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve()
+        })
+        pupilDataServiceFindOneSpy = jasmine.createSpy().and.callFake(function () {
+          return Promise.resolve(pupil)
+        })
         jwtService = proxyquire('../../services/jwt.service', {
-          '../models/pupil': Pupil
+          './data-access/pupil.data.service': {
+            update: pupilDataServiceUpdateSpy,
+            findOne: pupilDataServiceFindOneSpy
+          }
         })
       })
       it('then it throws an error', async (done) => {
         const token = await jwtService.createToken(pupil)
         try {
-          await jwtService.verify(token)
-          done('Not expected to get here')
+          await jwtService.verify(token.token)
+          expect('this').toBe('thrown')
         } catch (error) {
           expect(error.message).toBe('Unable to verify: invalid signature')
           done()
@@ -176,13 +202,20 @@ describe('JWT service', () => {
   })
 
   describe('break-in tests', () => {
-    let newPupil
+    let pupilDataServiceFindOneSpy
 
     beforeEach(() => {
-      newPupil = JSON.parse(JSON.stringify(pupil))
-      sandbox.mock(Pupil).expects('findOne').chain('lean').chain('exec').resolves(newPupil)
+      pupilDataServiceUpdateSpy = jasmine.createSpy().and.callFake(function () {
+        return Promise.resolve()
+      })
+      pupilDataServiceFindOneSpy = jasmine.createSpy().and.callFake(function () {
+        return Promise.resolve(pupil)
+      })
       jwtService = proxyquire('../../services/jwt.service', {
-        '../models/pupil': Pupil
+        './data-access/pupil.data.service': {
+          update: pupilDataServiceUpdateSpy,
+          findOne: pupilDataServiceFindOneSpy
+        }
       })
     })
     it('denies a token that has expired 1 hour ago', async (done) => {
@@ -193,12 +226,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000) - (60 * 60),         // Expires an hour ago
         nbf: Math.floor(Date.now() / 1000) - 60 * 60 * 2        // Not before
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt expired')
       }
@@ -213,12 +246,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000) - 1,                 // Expires 1s ago
         nbf: Math.floor(Date.now() / 1000) - 60 * 60 * 2        // Not before
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt expired')
       }
@@ -233,12 +266,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000) + 120,               // Expires in 120s
         nbf: Math.floor(Date.now() / 1000) + 60                 // Not before: becomes active in 60s
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt not active')
       }
@@ -253,12 +286,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000) + 120,               // Expires in 120s
         nbf: Math.floor(Date.now() / 1000) + 1                  // Not before: becomes active in 1s
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt not active')
       }
@@ -273,12 +306,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000) - 1,                 // Expired 1s ago
         nbf: Math.floor(Date.now() / 1000) + 1                  // Not before: becomes active in 1s
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt not active')
       }
@@ -293,12 +326,12 @@ describe('JWT service', () => {
         exp: Math.floor(Date.now() / 1000),                     // Expired now
         nbf: Math.floor(Date.now() / 1000)                      // Not before: becomes active mow
       }
-      newPupil.jwtSecret = 'testing123'
-      const token = jwt.sign(payload, newPupil.jwtSecret)
+      pupil.jwtSecret = 'testing123'
+      const token = jwt.sign(payload, pupil.jwtSecret)
       // Test
       try {
         await jwtService.verify(token)
-        done('Not expected to get here')
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error.message).toBe('Unable to verify: jwt expired')
       }

--- a/admin/spec/service/pupil-authentication.service.spec.js
+++ b/admin/spec/service/pupil-authentication.service.spec.js
@@ -46,6 +46,14 @@ describe('pupil authentication service', () => {
       expect(pupil).toEqual(pupilMock)
       done()
     })
+
+    it('prepares the pupil data', () => {
+      const pupil = new Pupil(pupilMock)
+      const pupilData = service.getPupilDataForSpa(pupil)
+      expect(pupilData.firstName).toBe(pupil.foreName)
+      expect(pupilData.lastName).toBe(pupil.lastName)
+      expect(pupilData.dob).toBe('31 December 2000')
+    })
   })
 
   describe('school not found', () => {

--- a/admin/spec/service/pupil-authentication.service.spec.js
+++ b/admin/spec/service/pupil-authentication.service.spec.js
@@ -4,9 +4,8 @@
 const sinon = require('sinon')
 require('sinon-mongoose')
 const proxyquire = require('proxyquire')
-const School = require('../../models/school')
-const Pupil = require('../../models/pupil')
-
+const schoolDataService = require('../../services/data-access/school.data.service')
+const pupilDataService = require('../../services/data-access/pupil.data.service')
 const schoolMock = require('../mocks/school')
 const pupilMock = require('../mocks/pupil')
 pupilMock.school = schoolMock
@@ -16,14 +15,11 @@ describe('pupil authentication service', () => {
 
   function setupService (schoolMock, pupilMock) {
     return proxyquire('../../services/pupil-authentication.service', {
-      '../models/school': sandbox.mock(School)
+      '../services/data-access/school.data.service': sandbox.mock(schoolDataService)
         .expects('findOne')
-        .chain('exec')
         .resolves(schoolMock),
-      '../models/pupil': sandbox.mock(Pupil)
+      '../models/pupil': sandbox.mock(pupilDataService)
         .expects('findOne')
-        .chain('populate')
-        .chain('exec')
         .resolves(pupilMock)
     })
   }
@@ -48,10 +44,9 @@ describe('pupil authentication service', () => {
     })
 
     it('prepares the pupil data', () => {
-      const pupil = new Pupil(pupilMock)
-      const pupilData = service.getPupilDataForSpa(pupil)
-      expect(pupilData.firstName).toBe(pupil.foreName)
-      expect(pupilData.lastName).toBe(pupil.lastName)
+      const pupilData = service.getPupilDataForSpa(pupilMock)
+      expect(pupilData.firstName).toBe(pupilMock.foreName)
+      expect(pupilData.lastName).toBe(pupilMock.lastName)
       expect(pupilData.dob).toBe('31 December 2000')
     })
   })
@@ -64,7 +59,7 @@ describe('pupil authentication service', () => {
     it('throws when the school is not found', async (done) => {
       try {
         await service.authenticate('pupilPin', 'badPin')
-        done(new Error('expected to throw'))
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error).toBeDefined()
         expect(error.message).toBe('Authentication failure')
@@ -81,7 +76,7 @@ describe('pupil authentication service', () => {
     it('throws when pupil is not found', async (done) => {
       try {
         await service.authenticate('badPin', 'schoolPin')
-        done(new Error('expected to throw'))
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error).toBeDefined()
         expect(error.message).toBe('Authentication failure')
@@ -98,7 +93,7 @@ describe('pupil authentication service', () => {
     it('throws when both pupil and school are not found', async (done) => {
       try {
         await service.authenticate('badPin', 'badPin')
-        done(new Error('expected to throw'))
+        expect('this').toBe('thrown')
       } catch (error) {
         expect(error).toBeDefined()
         expect(error.message).toBe('Authentication failure')

--- a/admin/vso-add-build-and-commit.sh
+++ b/admin/vso-add-build-and-commit.sh
@@ -2,10 +2,10 @@
 
 BUILD_FILE="./public/build.txt"
 touch $BUILD_FILE
-echo "$BUILD_BUILDNUMBER" > "$BUILD_FILE"
+echo "$BUILD_BUILDNUMBER" | tr '\n' ' ' > "$BUILD_FILE"
 cat $BUILD_FILE
 
 COMMIT_FILE="./public/commit.txt"
 touch $COMMIT_FILE
-echo "$BUILD_SOURCEVERSION" > $COMMIT_FILE
+echo "$BUILD_SOURCEVERSION" | tr '\n' ' ' > $COMMIT_FILE
 cat $COMMIT_FILE

--- a/pupil-spa/src/app/app.module.ts
+++ b/pupil-spa/src/app/app.module.ts
@@ -30,6 +30,7 @@ import { UserService } from './services/user/user.service';
 import { WarmupCompleteComponent } from './warmup-complete/warmup-complete.component';
 import { WarmupIntroComponent } from './warmup-intro/warmup-intro.component';
 import { WarmupQuestionService } from './services/question/warmup-question.service';
+import { WarmupLoadingComponent } from './warmup-loading/warmup-loading.component';
 
 const appRoutes: Routes = [
   {path: '', redirectTo: 'sign-in', pathMatch: 'full'},
@@ -60,7 +61,8 @@ const appRoutes: Routes = [
     LogoutComponent,
     QuestionComponent,
     WarmupCompleteComponent,
-    WarmupIntroComponent
+    WarmupIntroComponent,
+    WarmupLoadingComponent
   ],
   imports: [
     RouterModule.forRoot(

--- a/pupil-spa/src/app/check/check.component.html
+++ b/pupil-spa/src/app/check/check.component.html
@@ -1,5 +1,5 @@
 <h1 *ngIf="isWarmUp" class="page-header heading-small left">
-    <span class="warm-up-questions-label">Warm-up questions</span>
+    <span class="warm-up-questions-label">Practise questions</span>
 </h1>
 <div [ngSwitch]="viewState">
     <app-warmup-intro *ngSwitchCase="'warmup-intro'"

--- a/pupil-spa/src/app/check/check.component.html
+++ b/pupil-spa/src/app/check/check.component.html
@@ -5,6 +5,12 @@
     <app-warmup-intro *ngSwitchCase="'warmup-intro'"
                       (clickEvent)="warmupIntroClickHandler()">
     </app-warmup-intro>
+    <app-warmup-loading *ngSwitchCase="'warmup-preload'"
+                 [question]="question.sequenceNumber"
+                 [loadingTimeout]="config.loadingTime"
+                 (timeoutEvent)="loadingTimeoutHandler($event)"
+                 [total]="totalNumberOfQuestions">
+    </app-warmup-loading>
     <app-warmup-complete *ngSwitchCase="'warmup-complete'"
                        (clickEvent)="warmupCompleteClickHandler()">
     </app-warmup-complete>

--- a/pupil-spa/src/app/check/check.component.html
+++ b/pupil-spa/src/app/check/check.component.html
@@ -1,5 +1,5 @@
 <h1 *ngIf="isWarmUp" class="page-header heading-small left">
-    <span class="warm-up-questions-label">Practise questions</span>
+    <span class="warm-up-questions-label">Practice questions</span>
 </h1>
 <div [ngSwitch]="viewState">
     <app-warmup-intro *ngSwitchCase="'warmup-intro'"

--- a/pupil-spa/src/app/check/check.component.spec.ts
+++ b/pupil-spa/src/app/check/check.component.spec.ts
@@ -212,7 +212,7 @@ describe('CheckComponent', () => {
       testStateChange('warmup-intro', 'warmup-intro', true);
     });
     it('shows the warmup loading screen when the state is "LW<digit>"', () => {
-      testStateChange('LW1', 'preload', true);
+      testStateChange('LW1', 'warmup-preload', true);
     });
     it('shows the warmup question when the state is "W<digit>"', () => {
       testStateChange('W1', 'question', true);

--- a/pupil-spa/src/app/check/check.component.ts
+++ b/pupil-spa/src/app/check/check.component.ts
@@ -137,15 +137,15 @@ export class CheckComponent implements OnInit {
         break;
       case CheckComponent.warmupLoadingRe.test(stateDesc): {
         // Show the warmup-loading screen
-        const matches = /^LW(\d+)$/.exec(stateDesc);
+        const matches = CheckComponent.warmupLoadingRe.exec(stateDesc);
         this.question = this.warmupQuestionService.getQuestion(parseInt(matches[ 1 ], 10));
         this.isWarmUp = true;
-        this.viewState = 'preload';
+        this.viewState = 'warmup-preload';
         break;
       }
       case CheckComponent.warmupQuestionRe.test(stateDesc): {
         // Show the warmup question screen
-        const matches = /^W(\d+)$/.exec(stateDesc);
+        const matches = CheckComponent.warmupQuestionRe.exec(stateDesc);
         this.isWarmUp = true;
         // console.log(`state: ${stateDesc}: question is ${matches[ 1 ]}`);
         this.question = this.warmupQuestionService.getQuestion(parseInt(matches[ 1 ], 10));
@@ -161,7 +161,7 @@ export class CheckComponent implements OnInit {
       case CheckComponent.loadingRe.test(stateDesc): {
         // Show the loading screen
         this.isWarmUp = false;
-        const matches = /^L(\d+)$/.exec(stateDesc);
+        const matches = CheckComponent.loadingRe.exec(stateDesc);
         this.question = this.questionService.getQuestion(parseInt(matches[ 1 ], 10));
         this.viewState = 'preload';
         break;

--- a/pupil-spa/src/app/instructions/instructions.component.html
+++ b/pupil-spa/src/app/instructions/instructions.component.html
@@ -16,12 +16,12 @@
     </li>
     <li>You can press ‘Enter’ on the keyboard, number pad or on screen with your mouse.</li>
     <li>After {{questionTime}} seconds, the number in the answer box will be accepted, even if you haven't pressed ‘Enter’.</li>
-    <li>There will be 3 practise questions before you start the check.</li>
+    <li>There will be 3 practice questions before you start the check.</li>
   </ul>
 
   <div>
     <p>
-      <button class="button" (click)="onClick()" role="button" id="start-now-button">Start practise questions</button>
+      <button class="button" (click)="onClick()" role="button" id="start-now-button">Start practice questions</button>
     </p>
   </div>
 </div>

--- a/pupil-spa/src/app/instructions/instructions.component.html
+++ b/pupil-spa/src/app/instructions/instructions.component.html
@@ -16,12 +16,12 @@
     </li>
     <li>You can press ‘Enter’ on the keyboard, number pad or on screen with your mouse.</li>
     <li>After {{questionTime}} seconds, the number in the answer box will be accepted, even if you haven't pressed ‘Enter’.</li>
-    <li>There will be 3 warm-up questions before you start the check.</li>
+    <li>There will be 3 practise questions before you start the check.</li>
   </ul>
 
   <div>
     <p>
-      <button class="button" (click)="onClick()" role="button" id="start-now-button">Start warm-up questions</button>
+      <button class="button" (click)="onClick()" role="button" id="start-now-button">Start practise questions</button>
     </p>
   </div>
 </div>

--- a/pupil-spa/src/app/loading/loading.component.html
+++ b/pupil-spa/src/app/loading/loading.component.html
@@ -1,7 +1,7 @@
 <div class="preload" id="js-preload-div">
   <div>
     <p id="js-loading" class="font-large text-center">
-      Loading question {{question}} out of {{total}}
+      Question {{question}} out of {{total}}
     </p>
   </div>
 </div>

--- a/pupil-spa/src/app/login-success/login-success.component.html
+++ b/pupil-spa/src/app/login-success/login-success.component.html
@@ -4,14 +4,15 @@
       <h1 class="heading-xlarge">Welcome, {{pupil.firstName}}</h1>
     </header>
     <p class="lede">
-      Check your details below. Begin the multiplication tables check by clicking on ‘Read instructions’.
+      Check your details are correct. Begin by clicking ‘Read instructions’.
     </p>
     <br />
     <p id="first-name" class="lede">First name: <strong class="bold-medium">{{pupil.firstName}}</strong></p>
     <p id="last-name" class="lede">Last name: <strong class="bold-medium">{{pupil.lastName}}</strong></p>
     <p id="school" class="lede">School: <strong class="bold-medium">{{school.name}}</strong></p>
+    <p id="dob" class="lede">Date of Birth: <strong class="bold-medium">{{pupil.dob}}</strong></p>
     <p class="lede">
-      <a routerLink="/sign-out" >This is not me, I will enter my details again</a>
+      <a routerLink="/sign-out" >This is not me, I will try again</a>
     </p>
     <button class="button" (click)="onClick()">Read Instructions</button>
   </div>

--- a/pupil-spa/src/app/login-success/login-success.component.spec.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.spec.ts
@@ -49,7 +49,7 @@ describe('LoginSuccessComponent', () => {
 
   it('asks the user to confirm their details', () => {
     const compiled = fixture.debugElement.nativeElement;
-    expect(compiled.querySelector('p.lede').textContent).toMatch(/Check your details below/);
+    expect(compiled.querySelector('p.lede').textContent).toMatch(/Check your details are correct/);
   });
 
   it('redirects to warm up introduction page', () => {

--- a/pupil-spa/src/app/login-success/login-success.component.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.ts
@@ -20,6 +20,7 @@ export class LoginSuccessComponent implements OnInit {
     this.pupil = new Pupil;
     this.pupil.firstName = pupilData.firstName;
     this.pupil.lastName = pupilData.lastName;
+    this.pupil.dob = pupilData.dob;
     this.school = new School;
     this.school.name = schoolData.name;
   }

--- a/pupil-spa/src/app/login/login.component.html
+++ b/pupil-spa/src/app/login/login.component.html
@@ -13,8 +13,7 @@
         </header>
 
         <p class="lede">
-            To start your multiplication tables check, enter the school password and pupil PIN provided by your teacher,
-            then click ‘Sign in’.
+            Enter your school password and pupil PIN, then click <span class="nowrap">‘Sign in’</span>
         </p>
         <form (ngSubmit)="onSubmit(schoolPin.value, pupilPin.value)" autocomplete="off" autocapitalize="none">
             <div class="form-group">

--- a/pupil-spa/src/app/pupil.ts
+++ b/pupil-spa/src/app/pupil.ts
@@ -1,4 +1,5 @@
 export class Pupil {
   firstName: String;
   lastName: String;
+  dob: String;
 }

--- a/pupil-spa/src/app/warmup-complete/warmup-complete.component.html
+++ b/pupil-spa/src/app/warmup-complete/warmup-complete.component.html
@@ -1,11 +1,11 @@
 <br style="clear: both">
 <header class="page-header">
-    <h1 class="heading-xlarge">Practise completed</h1>
+    <h1 class="heading-xlarge">Practice completed</h1>
 </header>
 <div class="grid-row">
     <div class="column-two-thirds">
         <p class="lede">
-            You have completed the practise questions. Press ‘Start check’ when you are ready to start the real check.
+            You have completed the practice questions. Press ‘Start check’ when you are ready to start the real check.
         </p>
         <div>
             <button type="button" class="button button-start" id="start-now-button" (click)="onClick()">

--- a/pupil-spa/src/app/warmup-complete/warmup-complete.component.html
+++ b/pupil-spa/src/app/warmup-complete/warmup-complete.component.html
@@ -1,11 +1,11 @@
 <br style="clear: both">
 <header class="page-header">
-    <h1 class="heading-xlarge">Warm-up completed</h1>
+    <h1 class="heading-xlarge">Practise completed</h1>
 </header>
 <div class="grid-row">
     <div class="column-two-thirds">
         <p class="lede">
-            You have completed the warm-up questions. Press ‘Start check’ when you are ready to start the real check.
+            You have completed the practise questions. Press ‘Start check’ when you are ready to start the real check.
         </p>
         <div>
             <button type="button" class="button button-start" id="start-now-button" (click)="onClick()">

--- a/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
+++ b/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
@@ -1,6 +1,6 @@
 <br style="clear: both">
 <header class="page-header">
-  <h1 class="heading-xlarge">Practise questions</h1>
+  <h1 class="heading-xlarge">Practice questions</h1>
 </header>
 
 <div class="grid-row">

--- a/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
+++ b/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
@@ -5,8 +5,7 @@
 
 <div class="grid-row">
   <div class="column-two-thirds">
-    <p class="lede">Press 'Start now' to see 3 warm-up questions.
-      Use them to familiarise yourself with what the questions will look like and how to enter your answers.
+    <p class="lede">Now there will be 3 practice questions
     </p>
     <button class="button button-start" role="button" id="start-now-button" (click)="onClick()">Start now</button>
   </div>

--- a/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
+++ b/pupil-spa/src/app/warmup-intro/warmup-intro.component.html
@@ -1,6 +1,6 @@
 <br style="clear: both">
 <header class="page-header">
-  <h1 class="heading-xlarge">Warm-up questions</h1>
+  <h1 class="heading-xlarge">Practise questions</h1>
 </header>
 
 <div class="grid-row">

--- a/pupil-spa/src/app/warmup-loading/warmup-loading.component.html
+++ b/pupil-spa/src/app/warmup-loading/warmup-loading.component.html
@@ -1,7 +1,7 @@
 <div class="preload" id="js-preload-div">
   <div>
     <p id="js-loading" class="font-large text-center">
-      Practise question {{question}} out of {{total}}
+      Practice question {{question}} out of {{total}}
     </p>
   </div>
 </div>

--- a/pupil-spa/src/app/warmup-loading/warmup-loading.component.html
+++ b/pupil-spa/src/app/warmup-loading/warmup-loading.component.html
@@ -1,0 +1,7 @@
+<div class="preload" id="js-preload-div">
+  <div>
+    <p id="js-loading" class="font-large text-center">
+      Practise question {{question}} out of {{total}}
+    </p>
+  </div>
+</div>

--- a/pupil-spa/src/app/warmup-loading/warmup-loading.component.spec.ts
+++ b/pupil-spa/src/app/warmup-loading/warmup-loading.component.spec.ts
@@ -1,0 +1,31 @@
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { WarmupLoadingComponent } from './warmup-loading.component';
+import { AuditService } from '../services/audit/audit.service';
+import { AuditServiceMock } from '../services/audit/audit.service.mock';
+
+
+describe('WarmupLoadingComponent', () => {
+  let component: WarmupLoadingComponent;
+  let fixture: ComponentFixture<WarmupLoadingComponent>;
+
+  beforeEach(async(() => {
+    TestBed.configureTestingModule({
+      declarations: [ WarmupLoadingComponent ],
+      providers: [
+        { provide: AuditService, useClass: AuditServiceMock }
+      ]
+    })
+    .compileComponents();
+  }));
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(WarmupLoadingComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/pupil-spa/src/app/warmup-loading/warmup-loading.component.ts
+++ b/pupil-spa/src/app/warmup-loading/warmup-loading.component.ts
@@ -1,0 +1,16 @@
+import { Component, AfterViewInit } from '@angular/core';
+import { LoadingComponent } from '../loading/loading.component';
+import { AuditService } from '../services/audit/audit.service';
+
+@Component({
+  selector: 'app-warmup-loading',
+  templateUrl: './warmup-loading.component.html',
+  styles: []
+})
+export class WarmupLoadingComponent extends LoadingComponent implements AfterViewInit {
+
+  constructor(auditService: AuditService) {
+    super(auditService);
+  }
+
+}

--- a/pupil-spa/src/assets/shared-styles/elements/_organization-logo.scss
+++ b/pupil-spa/src/assets/shared-styles/elements/_organization-logo.scss
@@ -10,7 +10,7 @@
   line-height: $gutter-half;
   padding: 20px 0 0 6px;
 
-  @include media(tablet) {
+  @include media(desktop) {
     background-image: file-url('crests/org_crest_18px.png');
     background-position: 6px top;
     background-size: auto 25px;
@@ -18,16 +18,6 @@
     font-size: 18px;
     line-height: 20px;
     padding: 25px 0 0 7px;
-  }
-
-  @include media(desktop) {
-    background-image: file-url('crests/org_crest_27px.png');
-    background-position: 6px top;
-    background-size: auto 40px;
-    border-width: 3px;
-    font-size: 27px;
-    line-height: $gutter;
-    padding: 40px 0 0 10px;
   }
 }
 

--- a/pupil-spa/src/assets/shared-styles/styles.scss
+++ b/pupil-spa/src/assets/shared-styles/styles.scss
@@ -177,3 +177,7 @@ legend {
 /* General */
 /* Prevent anything on the screen being selectable */
 body { user-select: none; }
+
+.nowrap {
+  white-space: nowrap;
+}

--- a/pupil-spa/test/features/login_page.feature
+++ b/pupil-spa/test/features/login_page.feature
@@ -29,6 +29,7 @@ Feature: Login page
   Scenario: Users can login with valid credentials
     Given I have logged in
     Then I should be taken to the confirmation page
+    Then I should all the correct pupil details
 
   Scenario: Error is displayed when no details are entered
     Given I am on the sign in page

--- a/pupil-spa/test/features/step_definitions/check_steps.rb
+++ b/pupil-spa/test/features/step_definitions/check_steps.rb
@@ -109,7 +109,7 @@ end
 
 Then(/^I should see the total number of check questions$/) do
   questions = JSON.parse page.evaluate_script('window.localStorage.getItem("questions");')
-  expect(check_page.preload.text).to eql "Loading question 1 out of #{questions.size}"
+  expect(check_page.preload.text).to eql "Question 1 out of #{questions.size}"
 end
 
 Then(/^I should see all the data from the check stored in the DB$/) do

--- a/pupil-spa/test/features/step_definitions/login_page_steps.rb
+++ b/pupil-spa/test/features/step_definitions/login_page_steps.rb
@@ -83,3 +83,12 @@ Given(/^I have attempted to enter a school I do not attend upon login$/) do
   sign_in_page.login(schools.first['schoolPin'],@pupil_information['pin'])
   sign_in_page.sign_in_button.click
 end
+
+
+Then(/^I should all the correct pupil details$/) do
+  school = MongoDbHelper.find_school(9991999)['name']
+  expect(confirmation_page.first_name.text).to eql "First name: #{@pupil_information['foreName']}"
+  expect(confirmation_page.last_name.text).to  eql "Last name: #{@pupil_information['lastName']}"
+  expect(confirmation_page.school_name.text).to  eql "School: #{school}"
+  expect(confirmation_page.dob.text).to  eql "Date of Birth: #{@pupil_information['dob'].strftime("%-d %B %Y")}"
+end

--- a/pupil-spa/test/features/step_definitions/warm_up_steps.rb
+++ b/pupil-spa/test/features/step_definitions/warm_up_steps.rb
@@ -62,5 +62,5 @@ Given(/^I am on the warm up loading page$/) do
 end
 
 Then(/^I should see the total number of warm up questions$/) do
-  expect(check_page.preload.text).to eql 'Practise question 1 out of 3'
+  expect(check_page.preload.text).to eql 'Practice question 1 out of 3'
 end

--- a/pupil-spa/test/features/step_definitions/warm_up_steps.rb
+++ b/pupil-spa/test/features/step_definitions/warm_up_steps.rb
@@ -62,5 +62,5 @@ Given(/^I am on the warm up loading page$/) do
 end
 
 Then(/^I should see the total number of warm up questions$/) do
-  expect(check_page.preload.text).to eql 'Loading question 1 out of 3'
+  expect(check_page.preload.text).to eql 'Practise question 1 out of 3'
 end

--- a/pupil-spa/test/features/support/page_objects/confirmation_page.rb
+++ b/pupil-spa/test/features/support/page_objects/confirmation_page.rb
@@ -6,6 +6,7 @@ class ConfirmationPage < SitePrism::Page
   element :first_name, "#first-name"
   element :last_name, "#last-name"
   element :school_name, "#school"
+  element :dob, "#dob"
   element :back_sign_in_page, "a[href='/sign-out']"
   element :read_instructions,"button", text: 'Read Instructions'
   section :phase_banner, PhaseBanner, '.js-content .phase-banner'

--- a/pupil-spa/test/features/support/page_objects/sign_in_page.rb
+++ b/pupil-spa/test/features/support/page_objects/sign_in_page.rb
@@ -6,7 +6,7 @@ class SignInPage < SitePrism::Page
   element :footer_link, '.footer-wrapper .footer-meta .copyright a'
   section :phase_banner, PhaseBanner, '.js-content .phase-banner'
 
-  element :welcome_message, '.lede', text: "To start your multiplication tables check, enter the school password and pupil PIN provided by your teacher, then click ‘Sign in’."
+  element :welcome_message, '.lede', text: "Enter your school password and pupil PIN, then click ‘Sign in’"
 
   element :logo, '.organisation-logo'
   element :first_letter, '#last-name'

--- a/pupil-spa/test/features/support/page_objects/warm_up_complete_page.rb
+++ b/pupil-spa/test/features/support/page_objects/warm_up_complete_page.rb
@@ -1,8 +1,8 @@
 class WarmUpCompletePage < SitePrism::Page
   set_url '/check'
 
-  element :heading, '.heading-xlarge', text: "Practise completed"
-  element :completion_text, 'p.lede', text: "You have completed the practise questions. Press ‘Start check’ when you are ready to start the real check."
+  element :heading, '.heading-xlarge', text: "Practice completed"
+  element :completion_text, 'p.lede', text: "You have completed the practice questions. Press ‘Start check’ when you are ready to start the real check."
   element :start_check, '#start-now-button'
   element :warm_up_label, '.warm-up-questions-label'
   section :phase_banner, PhaseBanner, '.js-content .phase-banner'

--- a/pupil-spa/test/features/support/page_objects/warm_up_complete_page.rb
+++ b/pupil-spa/test/features/support/page_objects/warm_up_complete_page.rb
@@ -1,8 +1,8 @@
 class WarmUpCompletePage < SitePrism::Page
   set_url '/check'
 
-  element :heading, '.heading-xlarge', text: "Warm-up completed"
-  element :completion_text, 'p.lede', text: "You have completed the warm-up questions. Press ‘Start check’ when you are ready to start the real check."
+  element :heading, '.heading-xlarge', text: "Practise completed"
+  element :completion_text, 'p.lede', text: "You have completed the practise questions. Press ‘Start check’ when you are ready to start the real check."
   element :start_check, '#start-now-button'
   element :warm_up_label, '.warm-up-questions-label'
   section :phase_banner, PhaseBanner, '.js-content .phase-banner'

--- a/pupil-spa/test/features/support/page_objects/warm_up_page.rb
+++ b/pupil-spa/test/features/support/page_objects/warm_up_page.rb
@@ -6,7 +6,7 @@ class WarmUpPage < SitePrism::Page
   element :timer,'.remaining-time-warmup'
   element :question, '.question'
   element :start_warm_up_questions, '#start-now-button'
-  element :welcome_message, '.lede', text: "Press 'Start now' to see 3 practise questions. Use them to familiarise yourself with what the questions will look like and how to enter your answers."
+  element :welcome_message, '.lede', text: "Now there will be 3 practice questions"
   element :start_now, '#start-now-button'
   element :warm_up_label, '.warm-up-questions-label'
 

--- a/pupil-spa/test/features/support/page_objects/warm_up_page.rb
+++ b/pupil-spa/test/features/support/page_objects/warm_up_page.rb
@@ -1,7 +1,7 @@
 class WarmUpPage < SitePrism::Page
   set_url '/check'
 
-  element :heading, '.heading-xlarge', text: "Practise questions"
+  element :heading, '.heading-xlarge', text: "Practice questions"
   element :preload, '.preload'
   element :timer,'.remaining-time-warmup'
   element :question, '.question'

--- a/pupil-spa/test/features/support/page_objects/warm_up_page.rb
+++ b/pupil-spa/test/features/support/page_objects/warm_up_page.rb
@@ -1,12 +1,12 @@
 class WarmUpPage < SitePrism::Page
   set_url '/check'
 
-  element :heading, '.heading-xlarge', text: "Warm-up questions"
+  element :heading, '.heading-xlarge', text: "Practise questions"
   element :preload, '.preload'
   element :timer,'.remaining-time-warmup'
   element :question, '.question'
   element :start_warm_up_questions, '#start-now-button'
-  element :welcome_message, '.lede', text: "Press 'Start now' to see 3 warm-up questions. Use them to familiarise yourself with what the questions will look like and how to enter your answers."
+  element :welcome_message, '.lede', text: "Press 'Start now' to see 3 practise questions. Use them to familiarise yourself with what the questions will look like and how to enter your answers."
   element :start_now, '#start-now-button'
   element :warm_up_label, '.warm-up-questions-label'
 


### PR DESCRIPTION
Copy changes

But..

* api change on the spa client login / questions to return date of birth
* refactored pupil-authentication.service to move data access to data services
* jwtToken createToken() signature change
* add new warmup loading component to SPA as the html text is different for warmup questions
* and finally the copy changes requested
* and updated cucumber tests 
