### PR TITLE
Add dotenv package to admin app

### DIFF
--- a/admin/.dockerignore
+++ b/admin/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
 npm-debug.log
+.env

--- a/admin/.gitignore
+++ b/admin/.gitignore
@@ -55,3 +55,6 @@ test/*.json
 
 #ignore data files
 data/files/*
+
+# dotenv files
+.env

--- a/admin/app.js
+++ b/admin/app.js
@@ -1,5 +1,7 @@
 'use strict'
 
+require('dotenv').config()
+
 if (process.env.NODE_ENV === 'production') {
   require('newrelic')
 }

--- a/admin/bin/psychometricians-report-v2.js
+++ b/admin/bin/psychometricians-report-v2.js
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 'use strict'
 
+require('dotenv').config()
 const mongoose = require('mongoose')
 
 // const psychometricianReportService = require('../services/psychometrician-report.service')

--- a/admin/package.json
+++ b/admin/package.json
@@ -27,6 +27,7 @@
     "cookie-parser": "~1.4.3",
     "cors": "^2.8.4",
     "debug": "^3.1.0",
+    "dotenv": "^4.0.0",
     "ejs": "~2.5.6",
     "express": "^4.16.2",
     "express-breadcrumbs": "0.0.2",

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -1232,6 +1232,10 @@ dot-prop@^4.1.0:
   dependencies:
     is-obj "^1.0.0"
 
+dotenv@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-4.0.0.tgz#864ef1379aced55ce6f95debecdce179f7a0cd1d"
+
 dtrace-provider@~0.8:
   version "0.8.5"
   resolved "https://registry.yarnpkg.com/dtrace-provider/-/dtrace-provider-0.8.5.tgz#98ebba221afac46e1c39fd36858d8f9367524b92"


### PR DESCRIPTION
Dotenv adds the convenience of specifying environment variables in a `.env` file, which is not added to source control.  Therefore meaning you do not need to pass args, nor maintain these settings in your shell `rc` files.

I have explicitly added this to the ps report v2 for convenience.