### PR TITLE
set isTestAccount flag for speech synth user

### DIFF
--- a/admin/data/migrations/migrations/20180111142806-speech-synth-test-account-flag.js
+++ b/admin/data/migrations/migrations/20180111142806-speech-synth-test-account-flag.js
@@ -1,0 +1,14 @@
+'use strict'
+
+module.exports = {
+
+  up (db, next) {
+    db.collection('pupils').update({school: 9991999, foreName: 'Sam', lastName: 'Charles'}, { $set: {'isTestAccount': true} })
+    next()
+  },
+
+  down (db, next) {
+    db.collection('pupils').update({school: 9991999, foreName: 'Sam', lastName: 'Charles'}, { $set: {'isTestAccount': false} })
+    next()
+  }
+}


### PR DESCRIPTION
the speech synthesis enabled test account does not have the `isTestAccount` flag set, so the pin is being wiped every night when the pin purge job runs.