### PR TITLE
Feature/18298 pupil data refactor part 4

### DIFF
--- a/admin/services/data-access/pupil.data.service.js
+++ b/admin/services/data-access/pupil.data.service.js
@@ -33,13 +33,14 @@ pupilDataService.getPupils = async (schoolId) => {
 
 /**
  * Returns pupils filtered by school and sorted by field and direction (asc/desc)
- * @deprecated
+ * @deprecated use sqlFindPupilsByDfeNumber instead
  * @param schoolId
  * @param sortingField
  * @param sortingDirection
  * @returns {Array}
  */
 pupilDataService.getSortedPupils = async (schoolId, sortingField, sortingDirection) => {
+  winston.warn('*** pupilDataService.getSortedPupils is deprecated ***')
   const sort = {}
   sort[sortingField || 'lastName'] = sortingDirection || 'asc'
   return Pupil

--- a/admin/services/restart.service.js
+++ b/admin/services/restart.service.js
@@ -24,7 +24,7 @@ restartService.totalChecksAllowed = restartService.totalRestartsAllowed + 1
 restartService.getPupils = async (dfeNumber) => {
   const school = await schoolDataService.sqlFindOneByDfeNumber(dfeNumber)
   if (!school) throw new Error(`School [${dfeNumber}] not found`)
-  let pupils = await pupilDataService.getSortedPupils(dfeNumber, 'lastName', 'asc')
+  let pupils = await pupilDataService.sqlFindPupilsByDfeNumber(dfeNumber, 'lastName', 'asc')
   pupils = await bluebird.filter(pupils.map(async p => {
     const isPupilEligible = await restartService.isPupilEligible(p)
     if (isPupilEligible) return p

--- a/admin/services/restart.service.js
+++ b/admin/services/restart.service.js
@@ -118,7 +118,7 @@ restartService.canRestart = async pupilId => {
  */
 
 restartService.getSubmittedRestarts = async schoolId => {
-  let pupils = await pupilDataService.getSortedPupils(schoolId, 'lastName', 'asc')
+  let pupils = await pupilDataService.sqlFindPupilsByDfeNumber(schoolId, 'lastName', 'asc')
   if (!pupils || pupils.length === 0) return []
   let restarts = []
   // TODO: This loop is applied due to Cosmos MongoDB API bug and needs to be replaced with the new DB implementation
@@ -130,7 +130,7 @@ restartService.getSubmittedRestarts = async schoolId => {
     }
   }), p => !!p)
   pupils.map(p => {
-    const record = latestPupilRestarts.find(l => l.pupilId.toString() === p.id.toString())
+    const record = latestPupilRestarts.find(l => l.pupilId === p.id)
     if (record) {
       restarts.push({
         id: record.id,

--- a/admin/spec/service/restart.service.spec.js
+++ b/admin/spec/service/restart.service.spec.js
@@ -138,14 +138,14 @@ describe('restart.service', () => {
     it('returns a list of pupils who have been submitted for a restart', async () => {
       const pupil1 = Object.assign({}, pupilMock)
       const pupil2 = Object.assign({}, pupilMock)
-      spyOn(pupilDataService, 'getSortedPupils').and.returnValue([ pupil1, pupil2 ])
+      spyOn(pupilDataService, 'sqlFindPupilsByDfeNumber').and.returnValue([ pupil1, pupil2 ])
       spyOn(pupilRestartDataService, 'sqlFindLatestRestart').and.returnValue(pupilRestartMock)
       spyOn(restartService, 'getStatus').and.returnValue('Remove restart')
       const result = await restartService.getSubmittedRestarts(schoolMock._id)
       expect(result.length).toBe(2)
     })
     it('returns an empty list if no pupil has been submitted for a restart', async () => {
-      spyOn(pupilDataService, 'getSortedPupils').and.returnValue([])
+      spyOn(pupilDataService, 'sqlFindPupilsByDfeNumber').and.returnValue([])
       const result = await restartService.getSubmittedRestarts(schoolMock._id)
       expect(result.length).toBe(0)
     })

--- a/admin/spec/service/restart.service.spec.js
+++ b/admin/spec/service/restart.service.spec.js
@@ -37,7 +37,7 @@ describe('restart.service', () => {
       const pupil1 = Object.assign({}, pupilMock)
       const pupil2 = Object.assign({}, pupilMock)
       spyOn(schoolDataService, 'sqlFindOneByDfeNumber').and.returnValue(schoolMock)
-      spyOn(pupilDataService, 'getSortedPupils').and.returnValue([ pupil1, pupil2 ])
+      spyOn(pupilDataService, 'sqlFindPupilsByDfeNumber').and.returnValue([ pupil1, pupil2 ])
       spyOn(restartService, 'isPupilEligible').and.returnValue(true)
       let result
       try {


### PR DESCRIPTION
Remove legacy calls to pupilDataService.getSortedPupils() - now refactored to sql