### PR TITLE
make pin expiry time configurable

### DIFF
--- a/admin/config.js
+++ b/admin/config.js
@@ -57,5 +57,6 @@ module.exports = {
       app: 'MTC Admin',
       env: process.env.LOGDNA_ENV_NAME
     }
-  }
+  },
+  OverridePinExpiry: process.env.OVERRIDE_PIN_EXPIRY || false
 }

--- a/admin/services/pin-generation.service.js
+++ b/admin/services/pin-generation.service.js
@@ -12,8 +12,13 @@ const config = require('../config')
 
 const allowedWords = new Set((config.Data.allowedWords && config.Data.allowedWords.split(',')) || [])
 
-const fourPmToday = () => {
-  return moment().startOf('day').add(16, 'hours')
+const fourPmToday = moment().startOf('day').add(16, 'hours')
+
+const pinExpiryTime = () => {
+  if (config.OverridePinExpiry === 'true') {
+    return moment().endOf('day')
+  }
+  return fourPmToday
 }
 
 const pinGenerationService = {}
@@ -71,7 +76,7 @@ pinGenerationService.updatePupilPins = async (pupilsList) => {
   pupils.forEach(async pupil => {
     if (!pinValidator.isActivePin(pupil.pin, pupil.pinExpiresAt)) {
       pupil.pin = pinGenerationService.generatePupilPin()
-      pupil.pinExpiresAt = fourPmToday()
+      pupil.pinExpiresAt = pinExpiryTime()
     }
   })
   const data = pupils.map(p => ({ id: p.id, pin: p.pin, pinExpiresAt: p.pinExpiresAt }))
@@ -95,7 +100,7 @@ pinGenerationService.generateSchoolPassword = (school) => {
   const secondRandomWord = wordsArray[pinGenerationService.generateCryptoRandomNumber(0, wordsArray.length - 1)]
   const numberCombination = randomGenerator.getRandom(2, chars)
   const newPin = `${firstRandomWord}${numberCombination}${secondRandomWord}`
-  const newExpiry = fourPmToday()
+  const newExpiry = pinExpiryTime()
   return { pin: newPin, pinExpiresAt: newExpiry }
 }
 


### PR DESCRIPTION
For dev & test purposes, allow the pin expiry time to be configurable via `process.env.OVERRIDE_PIN_EXPIRY` which is exposed via `config.OverridePinExpiry`

I considered a check for production mode, but we may well want to test in production mode with this enabled.