### PR TITLE
configurable default passwords

### DIFF
--- a/admin/data/sql/migrations/054.do.update-admin-passwords.js
+++ b/admin/data/sql/migrations/054.do.update-admin-passwords.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const defaultPassword = process.env.DEFAULT_ADMIN_PASSWORD || '$2a$10$.WsawgZpWSAQVaa6Vz3P1.XO.1YntYJLd6Da5lrXCAkVxhhLpkOHK'
+
+module.exports.generateSql = () => {
+  return `UPDATE [mtc_admin].[user] TO ${defaultPassword}`
+}

--- a/admin/data/sql/migrations/054.undo.update-admin-passwords.js
+++ b/admin/data/sql/migrations/054.undo.update-admin-passwords.js
@@ -1,0 +1,7 @@
+'use strict'
+
+const defaultPassword = '$2a$10$.WsawgZpWSAQVaa6Vz3P1.XO.1YntYJLd6Da5lrXCAkVxhhLpkOHK'
+
+module.exports.generateSql = () => {
+  return `UPDATE [mtc_admin].[user] TO ${defaultPassword}`
+}


### PR DESCRIPTION
Migration gives an instance of the admin app the opportunity to configure different passwords for the default roles in the admin app.

This will typically be left as-is for dev and test environments.