### PR TITLE
Add another MS mime-type to the allowed mime-types for upload.

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -148,9 +148,10 @@ busboy.extend(app, {
   path: 'data/files',
   allowedPath: (url) => allowedPath(url),
   mimeTypeLimit: [
-    'text/csv',
-    'text/plain',
-    'application/octet-stream'
+    'text/csv', // correct
+    'text/plain', // IE8 sends this for csv
+    'application/octet-stream', // Google Chrome can send this for csv
+    'application/vnd.ms-excel' // Windows with Office installed sends this for csv
   ]
 })
 


### PR DESCRIPTION
Bugfix: allow Windows 10 with Office installed to upload csv files