### PR TITLE
remove surplus fields

### DIFF
--- a/admin/authentication/local-strategy.js
+++ b/admin/authentication/local-strategy.js
@@ -78,17 +78,15 @@ async function saveInvalidLogonEvent (logonEvent, message) {
     logonEvent.isAuthenticated = false
     await adminLogonEventDataService.sqlCreate(logonEvent)
   } catch (error) {
-    winston.warn('Failed to save logon event: ' + error.message)
+    winston.warn('Failed to save invalid logon event: ' + error.message)
   }
 }
 
 async function saveValidLogonEvent (logonEvent, session) {
   try {
     logonEvent.isAuthenticated = true
-    logonEvent.ncaEmailAddress = session.EmailAddress
-    logonEvent.ncaUserName = session.UserName
     await adminLogonEventDataService.sqlCreate(logonEvent)
   } catch (error) {
-    winston.warn('Failed to save logon event: ' + error.message)
+    winston.warn('Failed to save valid logon event: ' + error.message)
   }
 }


### PR DESCRIPTION
caught this in the log output from UAT and dev.

Fails to save valid logons because nca tools fields are passed in.  they are no longer needed.