### PR TITLE
bug/19059 - Bug fix.

### DIFF
--- a/admin/assets/javascripts/global-scripts.js
+++ b/admin/assets/javascripts/global-scripts.js
@@ -475,6 +475,11 @@ $(function () {
       groupFilters.tableRowVisibility(groupIds)
       stickyBanner.outputCheckedCheckboxes(inputStatus.countCheckedCheckboxes())
       stickyBanner.stickyBannerPositioning()
+      if (pupilsNotTakingCheck.isCheckboxChecked()) {
+        stickyBanner.toggle(true)
+      } else {
+        stickyBanner.toggle(false)
+      }
     })
 
     $('.filter-header').on('click', function (e) {


### PR DESCRIPTION
Re-validate sticky banner when group filters are applied to pupil's list.