### PR TITLE
Updates to copy and links 

### DIFF
--- a/admin/views/contact.ejs
+++ b/admin/views/contact.ejs
@@ -1,5 +1,8 @@
 <div class="grid-row">
-    <div class="column-full">
+    <div class="column-one-half">
+        <%- partial('partials/_breadcrumbs', { breadcrumbs: breadcrumbs }) %>
+    </div>
+    <div class="column-one-half">
         <%- partial('partials/_name_and_sign_out') %>
     </div>
 </div>

--- a/admin/views/partials/_footer_support_links.ejs
+++ b/admin/views/partials/_footer_support_links.ejs
@@ -1,8 +1,6 @@
 <h2 class="visuallyhidden">Support links</h2>
 <ul>
-  <li><a href="<%= govukRoot %>/help">Help</a></li>
   <li><a href="<%= govukRoot %>/help/cookies">Cookies</a></li>
   <li><a href="/contact">Contact</a></li>
-  <li><a href="<%= govukRoot %>/cymraeg">Cymraeg</a></li>
   <li>Built by the <a href="https://www.gov.uk/government/organisations/standards-and-testing-agency">Standards and Testing Agency</a></li>
 </ul>

--- a/admin/views/school/school-home.ejs
+++ b/admin/views/school/school-home.ejs
@@ -21,7 +21,7 @@
 
             <li>
                 <h2 class="heading-small"><a href="/school/pupils-not-taking-check">Pupils not taking the check</a></h2>
-                <p>Enter a reason for pupils who were unable to take the check</p>
+                <p>Enter a reason for pupils who are unable to take the check</p>
             </li>
 
             <li>
@@ -41,7 +41,7 @@
 
             <li>
                 <h2 class="heading-small"><a class="font-greyed-out disabled-link" href="/school/submit-attendance">Headteacher's declaration form</a></h2>
-                <p>Complete headteacher's declaration form once pupil register has been submitted</p>
+                <p>Complete the headteacher's declaration form after you have submitted your pupil register</p>
             </li>
 
             <li>


### PR DESCRIPTION
School landing page changes - 

- The summary under "Pupils not taking the check" change summary text to "Enter a reason for pupils who are unable to take the check" - change from "were" to "are"
- The summary under the HDF change summary text to "Complete the headteacher's declaration form after you have submitted your pupil register"


Remove Welsh link from footy
Add breadcrumbs to Contact page
Remove help from footer