### PR TITLE
toggle verbose express logging

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -90,25 +90,29 @@ const restart = require('./routes/restart')
 if (process.env.NODE_ENV === 'development') piping({ignore: [/test/, '/coverage/']})
 const app = express()
 
-/**
- * Express logging to winston
- */
-const expressWinston = require('express-winston')
-app.use(expressWinston.logger({
-  transports: [
-    new winston.transports.Console({
-      json: true,
-      colorize: true
-    })
-  ],
-  meta: true, // optional: control whether you want to log the meta data about the request (default to true)
-  // msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
-  expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
-  colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
-  ignoreRoute: function (req, res) {
-    return false
-  } // optional: allows to skip some log messages based on request and/or response
-}))
+if (config.Logging.Express.UseWinston === 'true') {
+  /**
+   * Express logging to winston
+   */
+  const expressWinston = require('express-winston')
+  app.use(expressWinston.logger({
+    transports: [
+      new winston.transports.Console({
+        json: true,
+        colorize: true
+      })
+    ],
+    meta: true, // optional: control whether you want to log the meta data about the request (default to true)
+    // msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
+    expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
+    colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+    ignoreRoute: function (req, res) {
+      return false
+    } // optional: allows to skip some log messages based on request and/or response
+  }))
+} else {
+  app.use(morgan('dev'))
+}
 
 /* Security Directives */
 
@@ -169,7 +173,6 @@ app.set('view engine', 'ejs')
 // app.use(favicon(path.join(__dirname, 'public', 'favicon.ico')))
 
 app.use(partials())
-// app.use(morgan('dev'))
 busboy.extend(app, {
   upload: true,
   path: 'data/files',

--- a/admin/config.js
+++ b/admin/config.js
@@ -60,6 +60,9 @@ module.exports = {
       mac: undefined,
       app: `MTCAdmin:${getEnvironment()}`,
       env: `${getEnvironment()}`
+    },
+    Express: {
+      UseWinston: process.env.EXPRESS_LOGGING_WINSTON || false
     }
   },
   OverridePinExpiry: process.env.OVERRIDE_PIN_EXPIRY || false,


### PR DESCRIPTION
further to the implementation of express logging via winston, this change ensures it is only enabled if explicitly configured, and defaults back to morgan for less verbose dev output.