### PR TITLE
Fix CSP policy for Safari

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -123,9 +123,9 @@ app.use(helmet.contentSecurityPolicy({
     defaultSrc: ["'self'"],
     scriptSrc: ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com'],
     fontSrc: ["'self'", 'data:'],
-    styleSrc: ["'self'"],
+    styleSrc: ["'self'", "'unsafe-inline'"],
     imgSrc: ["'self'", 'https://www.google-analytics.com', 'data:'],
-    connectSrc: ["'self'"],
+    connectSrc: ["'self'", 'https://www.google-analytics.com'],
     objectSrc: ["'none'"],
     mediaSrc: ["'none'"],
     childSrc: ["'none'"]


### PR DESCRIPTION
* GA required connect-src for google-analytics
* unsafe-inline error fixed, but the underlying cause needs understanding