### PR TITLE
disable insights error handling and logging

### DIFF
--- a/admin-assets/nginx/default.conf
+++ b/admin-assets/nginx/default.conf
@@ -5,6 +5,8 @@ server {
    # don't send the nginx version number in error pages and Server header
   server_tokens off;
 
+  error_log /dev/stdout debug;
+
   listen 80;
 
   sendfile on;
@@ -39,7 +41,7 @@ server {
   # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
   # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
   # also https://hstspreload.org/
-  add_header Strict-Transport-Security "max-age=31536000;";
+  # add_header Strict-Transport-Security "max-age=31536000;";
 
   # config to stop the browser rendering a page inside a frame or iframe
   # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking

--- a/admin-assets/nginx/default.conf
+++ b/admin-assets/nginx/default.conf
@@ -5,8 +5,6 @@ server {
    # don't send the nginx version number in error pages and Server header
   server_tokens off;
 
-  error_log /dev/stdout debug;
-
   listen 80;
 
   sendfile on;
@@ -41,7 +39,7 @@ server {
   # config to enable HSTS(HTTP Strict Transport Security) https://developer.mozilla.org/en-US/docs/Security/HTTP_Strict_Transport_Security
   # to avoid ssl stripping https://en.wikipedia.org/wiki/SSL_stripping#SSL_stripping
   # also https://hstspreload.org/
-  # add_header Strict-Transport-Security "max-age=31536000;";
+  add_header Strict-Transport-Security "max-age=31536000;";
 
   # config to stop the browser rendering a page inside a frame or iframe
   # and avoid clickjacking http://en.wikipedia.org/wiki/Clickjacking

--- a/admin/azure.js
+++ b/admin/azure.js
@@ -9,7 +9,15 @@ const azure = {
   },
   startInsightsIfConfigured: () => {
     if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
-      appInsights.setup().start()
+      appInsights.setup()
+        .setAutoDependencyCorrelation(true)
+        .setAutoCollectRequests(true)
+        .setAutoCollectPerformance(true)
+        .setAutoCollectExceptions(false)
+        .setAutoCollectDependencies(true)
+        .setAutoCollectConsole(false)
+        .setUseDiskRetryCaching(true)
+        .start()
     }
   }
 }


### PR DESCRIPTION
this should stop app insights package from trying to process errors.
also stops it capturing logging from winston.