### PR TITLE
Update the Psychometric report

### DIFF
--- a/admin/services/data-access/completed-check.data.service.js
+++ b/admin/services/data-access/completed-check.data.service.js
@@ -78,7 +78,9 @@ completedCheckDataService.sqlFindByIds = async (batchIds) => {
  * @description returns a boolean indicating whether there are unmarked checks in the database
  */
 completedCheckDataService.sqlHasUnmarked = async () => {
-  const sql = `SELECT COUNT(*) as [unmarkedCount] FROM [mtc_admin].[check] WHERE markedAt IS NULL`
+  const sql = `SELECT COUNT(*) as [unmarkedCount] FROM [mtc_admin].[check] 
+    WHERE markedAt IS NULL 
+    AND [data] IS NOT NULL`
   const result = await sqlService.query(sql)
   return result[0].unmarkedCount > 0
 }
@@ -94,7 +96,9 @@ completedCheckDataService.sqlFindUnmarked = async function (batchSize) {
   }
   const safeBatchSize = parseInt(batchSize, 10)
 
-  const sql = `SELECT TOP ${safeBatchSize} id FROM [mtc_admin].[check] WHERE markedAt IS NULL`
+  const sql = `SELECT TOP ${safeBatchSize} id FROM [mtc_admin].[check] 
+  WHERE markedAt IS NULL
+  AND [data] IS NOT NULL`
   const results = await sqlService.query(sql)
   return results.map(r => r.id)
 }

--- a/admin/services/data-access/psychometrician-report-cache.data.service.js
+++ b/admin/services/data-access/psychometrician-report-cache.data.service.js
@@ -67,7 +67,7 @@ const psychometricianReportCacheDataService = {
    * @return {Promise<*>}
    */
   sqlFindUnprocessedChecks: async function () {
-    const sql = `SELECT c.* 
+    const sql = `SELECT TOP 250 c.* 
       FROM ${sqlService.adminSchema}.${table} p 
       RIGHT OUTER JOIN ${sqlService.adminSchema}.[check] c ON p.check_id = c.id 
       WHERE p.check_id IS NULL


### PR DESCRIPTION
*  `sqlFindUnprocessedChecks` - now only returns at most 250 checks.  This fixes a bug where large reports caused SQL Server to reject the update
* update `completedCheckDataService` - to only find rows that have something in the `data` column