### PR TITLE
20241 - Fixed the Chrome errors that occur when building the test containers

### DIFF
--- a/test/admin/Dockerfile
+++ b/test/admin/Dockerfile
@@ -34,6 +34,7 @@ RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RE
 # Install Google Chrome
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
     apt-get -yqq install google-chrome-stable && \
     rm -rf /var/lib/apt/lists/*
 

--- a/test/pupil/Dockerfile
+++ b/test/pupil/Dockerfile
@@ -34,6 +34,7 @@ RUN CHROMEDRIVER_VERSION=`curl -sS chromedriver.storage.googleapis.com/LATEST_RE
 # Install Google Chrome
 RUN curl -sS -o - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - && \
     echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list && \
+    apt-get update && \
     apt-get -yqq install google-chrome-stable && \
     rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
The test containers require google-chrome-stable and had the apt sources added,
but there was no apt-get update to refresh the source list after it, so there was an
error thrown that 'google-chrome-stable could not be found'.