### PR TITLE
bug/20218 Updated input type and pattern for pupilPin input

### DIFF
--- a/admin/spec/service/psychometrician-util.service.spec.js
+++ b/admin/spec/service/psychometrician-util.service.spec.js
@@ -240,7 +240,7 @@ describe('psychometrician-util.service', () => {
           input: 'left click',
           eventType: 'mousedown',
           clientInputDate: '2018-03-05T14:05:32.377Z',
-          question: 2,
+          question: 2
         },
         {
           input: 'enter',
@@ -783,7 +783,6 @@ describe('psychometrician-util.service', () => {
       const res = service.getTimeoutFlag(input)
       expect(res).toBe(0)
     })
-
   })
 
   describe('#getTimeoutWithNoResponseFlag', () => {

--- a/pupil-spa/src/app/login/login.component.html
+++ b/pupil-spa/src/app/login/login.component.html
@@ -22,7 +22,7 @@
             </div>
             <div class="form-group">
                 <label for="pupilPin" class="form-label-bold"> Pupil PIN </label>
-                <input #pupilPin id="pupilPin" class="form-control" required minlength="1" [(ngModel)]="loginModel.pupilPin" name="pupilPin" spellcheck="false" autocorrect="off">
+                <input #pupilPin id="pupilPin" class="form-control" required minlength="1" [(ngModel)]="loginModel.pupilPin" name="pupilPin" spellcheck="false" autocorrect="off" type="number" pattern="\d*">
             </div>
             <div class="form-group">
                 <p>


### PR DESCRIPTION
In order for mobiles to detect the input as numeric, the input type
has to have type="number" and pattern="\d*" as per HTML5 standards.