### PR TITLE
reset feature toggles on UAT

### DIFF
--- a/admin/config/feature-toggles.Azure-UAT.json
+++ b/admin/config/feature-toggles.Azure-UAT.json
@@ -1,8 +1,8 @@
 {
-  "groupCreate": false,
-  "groupRemove": false,
-  "groupEdit": false,
-  "pupilAdd": false,
-  "pupilEdit": false,
-  "pupilUpload": false
+  "groupCreate": true,
+  "groupEdit": true,
+  "groupRemove": true,
+  "pupilAdd": true,
+  "pupilEdit": true,
+  "pupilUpload": true
 }


### PR DESCRIPTION
Product owner has requested that UAT behave as default now that the trials are complete.

Rather than delete the UAT configuration and let it fall back to default behaviours, i have left the file in as an example of how it is done.