### PR TITLE
sql connection - default to UTC

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -232,8 +232,7 @@ const sessionOptions = {
         port: config.Sql.Port,
         database: config.Sql.Database,
         encrypt: true,
-        requestTimeout: config.Sql.Timeout,
-        useUTC: false
+        requestTimeout: config.Sql.Timeout
       }
     },
     tableName: '[mtc_admin].[sessions]'

--- a/admin/services/data-access/sql.pool.service.js
+++ b/admin/services/data-access/sql.pool.service.js
@@ -19,8 +19,7 @@ var connectionConfig = {
     port: config.Sql.Port,
     database: config.Sql.Database,
     encrypt: true,
-    requestTimeout: config.Sql.Timeout,
-    useUTC: false
+    requestTimeout: config.Sql.Timeout
   }
 }
 


### PR DESCRIPTION
This should not affect MTC, as we use `dateTimeOffset`

omitting the value defaults it to `true`

however, its worthwhile running through a full test to see if anything is raised.