### PR TITLE
Changed the migration error handling to stop the process immediately

### DIFF
--- a/admin/data/sql/migrate-sql.js
+++ b/admin/data/sql/migrate-sql.js
@@ -47,6 +47,7 @@ const runMigrations = async () => {
     error.appliedMigrations.forEach(migration => {
       winston.error(migration.name)
     })
+    throw new Error(error)
   }
 }
 
@@ -59,9 +60,9 @@ try {
     },
     (error) => {
       winston.info(chalk.red(error.message))
-      process.exitCode = 1
+      process.exit(1)
     })
 } catch (error) {
   winston.error(`Error caught: ${error.message}`)
-  process.exitCode = 1
+  process.exit(1)
 }


### PR DESCRIPTION
Now throwing the error inside the runMigrations async function, which will
be catched in the outer try, which does process.exit(1)

The process.exitCode previously added should have had a throw afterwards
to stop the process, but it doesn't handle the promises well, so .exit(1) does the job