### PR TITLE
feature/20766 introduce app insights as winston destination

### DIFF
--- a/admin/azure.js
+++ b/admin/azure.js
@@ -1,4 +1,5 @@
 const appInsights = require('applicationinsights')
+const config = require('./config')
 
 const azure = {
   /**
@@ -8,7 +9,7 @@ const azure = {
     return process.env.KUDU_APPPATH !== undefined
   },
   startInsightsIfConfigured: () => {
-    if (process.env.APPINSIGHTS_INSTRUMENTATIONKEY) {
+    if (config.Logging.ApplicationInsights.Key) {
       appInsights.setup()
         .setAutoDependencyCorrelation(true)
         .setAutoCollectRequests(true)

--- a/admin/config.js
+++ b/admin/config.js
@@ -66,6 +66,10 @@ module.exports = {
     },
     Express: {
       UseWinston: process.env.EXPRESS_LOGGING_WINSTON || false
+    },
+    ApplicationInsights: {
+      LogToWinston: process.env.APPINSIGHTS_WINSTON_LOGGER || false,
+      Key: process.env.APPINSIGHTS_INSTRUMENTATIONKEY
     }
   },
   OverridePinExpiry: process.env.hasOwnProperty('OVERRIDE_PIN_EXPIRY') ? toBool(process.env.OVERRIDE_PIN_EXPIRY) : false,

--- a/admin/helpers/logger.js
+++ b/admin/helpers/logger.js
@@ -1,0 +1,65 @@
+'use strict'
+
+const winston = require('winston')
+const config = require('../config')
+const morgan = require('morgan')
+
+let initialised
+
+const init = (app) => {
+  if (initialised) return
+  /**
+ * Logging
+ * use LogDNA transport for winston if configuration setting available
+ */
+  if (config.Logging.LogDna.key) {
+    require('logdna')
+    const options = config.Logging.LogDna
+    // Defaults to false, when true ensures meta object will be searchable
+    options.index_meta = true
+    // Only add this line in order to track exceptions
+    options.handleExceptions = true
+    winston.add(winston.transports.Logdna, options)
+    winston.info(`logdna transport enabled for ${options.hostname}`)
+  }
+
+  if (process.env.NODE_ENV !== 'production') {
+    winston.level = 'debug'
+  }
+
+  if (config.Logging.Express.UseWinston === 'true') {
+    /**
+     * Express logging to winston
+     */
+    const expressWinston = require('express-winston')
+    app.use(expressWinston.logger({
+      transports: [
+        new winston.transports.Console({
+          json: true,
+          colorize: true
+        })
+      ],
+      meta: true, // optional: control whether you want to log the meta data about the request (default to true)
+      // msg: "HTTP {{req.method}} {{req.url}}", // optional: customize the default logging message. E.g. "{{res.statusCode}} {{req.method}} {{res.responseTime}}ms {{req.url}}"
+      expressFormat: true, // Use the default Express/morgan request formatting. Enabling this will override any msg if true. Will only output colors with colorize set to true
+      colorize: false, // Color the text and status code, using the Express/morgan color palette (text: gray, status: default green, 3XX cyan, 4XX yellow, 5XX red).
+      ignoreRoute: function (req, res) {
+        return false
+      } // optional: allows to skip some log messages based on request and/or response
+    }))
+  } else {
+    app.use(morgan('dev'))
+  }
+
+  if (config.Logging.ApplicationInsights.LogToWinston) {
+    const aiLogger = require('winston-azure-application-insights').AzureApplicationInsightsLogger
+
+    winston.add(aiLogger, {
+      key: config.Logging.ApplicationInsights.Key
+    })
+    winston.info(`app insights winston transport enabled`)
+  }
+  initialised = true
+}
+
+module.exports = init

--- a/admin/package.json
+++ b/admin/package.json
@@ -69,6 +69,7 @@
     "validate": "^3.0.1",
     "validator": "^9.4.0",
     "winston": "^2.4.0",
+    "winston-azure-application-insights": "^1.3.0",
     "xregexp": "^3.2.0"
   },
   "devDependencies": {

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -204,6 +204,14 @@ applicationinsights@^0.22.0:
     diagnostic-channel-publishers "0.2.1"
     zone.js "0.7.6"
 
+applicationinsights@^1.0:
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/applicationinsights/-/applicationinsights-1.0.3.tgz#ddbf503612cbbfd7c28e087894dd28cfb06450a1"
+  dependencies:
+    diagnostic-channel "0.2.0"
+    diagnostic-channel-publishers "0.2.1"
+    zone.js "0.7.6"
+
 aproba@^1.0.3:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/aproba/-/aproba-1.2.0.tgz#6802e6264efd18c790a1b0d517f0f2627bf2c94a"
@@ -6146,9 +6154,27 @@ window-size@0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/window-size/-/window-size-0.1.0.tgz#5438cd2ea93b202efa3a19fe8887aee7c94f9c9d"
 
+winston-azure-application-insights@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/winston-azure-application-insights/-/winston-azure-application-insights-1.3.0.tgz#a9b451fe17cc1e6a4cba6cae8b45afef033b8cc7"
+  dependencies:
+    applicationinsights "^1.0"
+    winston "^2.3.0"
+
 winston@^2.2.0, winston@^2.4.0:
   version "2.4.0"
   resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.0.tgz#808050b93d52661ed9fb6c26b3f0c826708b0aee"
+  dependencies:
+    async "~1.0.0"
+    colors "1.0.x"
+    cycle "1.0.x"
+    eyes "0.1.x"
+    isstream "0.1.x"
+    stack-trace "0.0.x"
+
+winston@^2.3.0:
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/winston/-/winston-2.4.2.tgz#3ca01f763116fc48db61053b7544e750431f8db0"
   dependencies:
     async "~1.0.0"
     colors "1.0.x"


### PR DESCRIPTION
Sends winston logs to application insights, when enabled.

- Refactored logging setup to dedicated file under helpers directory
- Added formal config settings for app insights key 

<img width="914" alt="screenshot 2018-06-07 14 00 40" src="https://user-images.githubusercontent.com/329532/41101864-45bfc484-6a5d-11e8-8e48-d6a8676e2c12.png">
