### PR TITLE
feature/21581 Implement restrictive CORS policy for endpoints only

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -89,7 +89,6 @@ app.use(featureToggles.middleware)
 
 /* Security Directives */
 
-// app.use(cors())
 app.use(helmet())
 const scriptSources = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com', 'https://www.googletagmanager.com']
 const styleSources = ["'self'", "'unsafe-inline'"]

--- a/admin/app.js
+++ b/admin/app.js
@@ -5,7 +5,6 @@ require('dotenv').config()
 const express = require('express')
 const piping = require('piping')
 const path = require('path')
-const morgan = require('morgan')
 const busboy = require('express-busboy')
 const partials = require('express-partials')
 const uuidV4 = require('uuid/v4')
@@ -16,7 +15,6 @@ const CustomStrategy = require('passport-custom').Strategy
 const session = require('express-session')
 const TediousSessionStore = require('connect-tedious')(session)
 const breadcrumbs = require('express-breadcrumbs')
-const cors = require('cors')
 const flash = require('connect-flash')
 const helmet = require('helmet')
 const config = require('./config')
@@ -91,7 +89,7 @@ app.use(featureToggles.middleware)
 
 /* Security Directives */
 
-app.use(cors())
+// app.use(cors())
 app.use(helmet())
 const scriptSources = ["'self'", "'unsafe-inline'", 'https://www.google-analytics.com', 'https://www.googletagmanager.com']
 const styleSources = ["'self'", "'unsafe-inline'"]
@@ -150,7 +148,7 @@ app.use((req, res, next) => {
 
 /* END:Security Directives */
 
-require('./helpers')(app)
+require('./helpers/index')(app)
 
 // view engine setup
 app.set('views', path.join(__dirname, 'views'))

--- a/admin/config.js
+++ b/admin/config.js
@@ -91,5 +91,8 @@ module.exports = {
     username: process.env.ESB_USER || 'guest',
     password: process.env.ESB_PASSWORK || 'guest',
     protocol: process.env.ESB_PROTOCOL || 'amqp' // Azure requires amqps
+  },
+  Cors: {
+    Whitelist: process.env.CORS_WHITELIST || 'http://localhost:4200' // for development
   }
 }

--- a/admin/helpers/cors-options.js
+++ b/admin/helpers/cors-options.js
@@ -1,0 +1,16 @@
+'use strict'
+
+const config = require('../config')
+const whitelist = config.Cors.Whitelist.split(',')
+
+const options = {
+  origin: function (origin, callback) {
+    if (whitelist.indexOf(origin) !== -1) {
+      callback(null, true)
+    } else {
+      callback(new Error(`CORS policy does not allow ${origin}`))
+    }
+  }
+}
+
+module.exports = options

--- a/admin/routes/check-started.js
+++ b/admin/routes/check-started.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const router = express.Router()
 const { checkStarted } = require('../controllers/check-started')
+const cors = require('cors')
+const corsOptions = require('../helpers/cors-options')
 
-router.route('/').all((req, res) => {
+router.route('/').all(cors(corsOptions), (req, res) => {
   if (req.method !== 'POST') return res.sendStatus(405)
   checkStarted(req, res)
 })

--- a/admin/routes/completed-check.js
+++ b/admin/routes/completed-check.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const router = express.Router()
 const { postCheck } = require('../controllers/completed-check')
+const cors = require('cors')
+const corsOptions = require('../helpers/cors-options')
 
-router.route('/').all((req, res) => {
+router.route('/').all(cors(corsOptions), (req, res) => {
   if (req.method !== 'POST') return res.sendStatus(405)
   postCheck(req, res)
 })

--- a/admin/routes/pupil-feedback.js
+++ b/admin/routes/pupil-feedback.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const router = express.Router()
 const { setPupilFeedback } = require('../controllers/pupil-feedback')
+const cors = require('cors')
+const corsOptions = require('../helpers/cors-options')
 
-router.route('/').all((req, res) => {
+router.route('/').all(cors(corsOptions), (req, res) => {
   if (req.method !== 'POST') return res.sendStatus(405)
   setPupilFeedback(req, res)
 })

--- a/admin/routes/questions.js
+++ b/admin/routes/questions.js
@@ -1,8 +1,10 @@
 const express = require('express')
 const router = express.Router()
 const { getQuestions } = require('../controllers/questions')
+const cors = require('cors')
+const corsOptions = require('../helpers/cors-options')
 
-router.route('/').all((req, res) => {
+router.route('/').all(cors(corsOptions), (req, res) => {
   if (req.method !== 'POST') return res.sendStatus(405)
   getQuestions(req, res)
 })

--- a/test/admin/features/step_definitions/add_multiple_pupil_steps.rb
+++ b/test/admin/features/step_definitions/add_multiple_pupil_steps.rb
@@ -63,8 +63,8 @@ end
 And(/^I can see the new pupil in the list$/) do
   hightlighted_rows = pupil_register_page.pupil_list.pupil_row.find_all{|row| row.has_edited_pupil?}
   hightlighted_row_list = hightlighted_rows.map{|x| x.names.text}
-  expect(hightlighted_row_list).to include("#{@pupil_name}, #{@pupil_name} #{@pupil_name} Date of birth:#{(Date.parse(@old_date1)).strftime('%e %b %Y')}")
-  expect(hightlighted_row_list).to include("#{@pupil_name}, #{@pupil_name} #{@pupil_name} Date of birth:#{(Date.parse(@old_date1)).strftime('%e %b %Y')}")
+  expect(hightlighted_row_list).to include("#{@pupil_name}, #{@pupil_name} #{@pupil_name} Date of birth: #{(Date.parse(@old_date1)).strftime('%e %b %Y')}")
+  expect(hightlighted_row_list).to include("#{@pupil_name}, #{@pupil_name} #{@pupil_name} Date of birth: #{(Date.parse(@old_date1)).strftime('%e %b %Y')}")
 end
 
 And(/^I can see the error message for adding Multiple Pupil$/) do


### PR DESCRIPTION
- Remove global wildcard policy
- Implement 'per endpoint' policies
- Allow multiple whitelist domains via config 