### PR TITLE
Fix regression that prevent scrolling on tablets using touch input

### DIFF
--- a/pupil-spa/src/assets/shared-styles/styles.scss
+++ b/pupil-spa/src/assets/shared-styles/styles.scss
@@ -219,7 +219,7 @@ legend {
 /* Prevent anything on the screen being selectable */
 body {
   user-select: none;
-  -ms-touch-action: none !important; /* Disable double-tap zoom */
+  -ms-touch-action: manipulation !important; /* Disable double-tap zoom */
 }
 
 .nowrap {


### PR DESCRIPTION
Allow scrolling using touch input - IE11 Windows 10 touchscreen 