### PR TITLE
22015 - Increase timeout for pupil data generation to 5 minutes

### DIFF
--- a/admin/controllers/check-form.js
+++ b/admin/controllers/check-form.js
@@ -508,6 +508,8 @@ const getFileDownloadPupilCheckData = async (req, res, next) => {
  * @returns {Promise.<void>}
  */
 const getGenerateLatestPupilCheckData = async (req, res, next) => {
+  req.setTimeout(5 * 1000 * 60) // 5 minutes
+
   try {
     await checkProcessingService.process()
 

--- a/admin/views/test-developer/download-pupil-check-data.ejs
+++ b/admin/views/test-developer/download-pupil-check-data.ejs
@@ -65,7 +65,7 @@
 
         $.ajax({
             url: '/test-developer/generate-latest-pupil-check-data',
-            timeout: 60 * 1000
+            timeout: 60 * 1000 * 5
         })
             .done(function(data) {
                 $(contentId).html(`


### PR DESCRIPTION
# HOTFIX -> 2018-june-trial branch

* Increase ajax timeout to 5 mins
* Increase POST controller timeout to 5 mins
* Tested in docker - 5 min timeout observed
* changes to admin only

NOTE - production observes a 30-second timeout, whereas a 1-minute timeout was observed locally which was the ajax timeout.  This suggests that there is something else in prod that is causing the timeout.