### PR TITLE
Bug/22133 Remove pupil localstorage after login

### DIFF
--- a/pupil-spa/src/app/login-success/login-success.component.spec.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.spec.ts
@@ -69,9 +69,10 @@ describe('LoginSuccessComponent', () => {
     fixture.detectChanges();
   });
 
-  it('should be created', () => {
+  it('should be created and remove pupil data', () => {
     expect(component).toBeTruthy();
     expect(appUsageService.increment).toHaveBeenCalledTimes(1);
+    expect(storageService.setItem).toHaveBeenCalledTimes(1);
   });
 
   it('asks the user to confirm their details', () => {
@@ -79,10 +80,9 @@ describe('LoginSuccessComponent', () => {
     expect(compiled.querySelector('p.lede').textContent).toMatch(/If this is you, please confirm/);
   });
 
-  it('redirects to warm up introduction page and removes pupil data', () => {
+  it('redirects to warm up introduction page', () => {
     component.onClick();
     expect(mockRouter.navigate).toHaveBeenCalledWith(['check-start']);
-    expect(storageService.setItem).toHaveBeenCalledTimes(1);
   });
 
 });

--- a/pupil-spa/src/app/login-success/login-success.component.ts
+++ b/pupil-spa/src/app/login-success/login-success.component.ts
@@ -50,6 +50,10 @@ export class LoginSuccessComponent implements OnInit, AfterViewInit, OnDestroy {
     this.school = new School;
     this.school.name = schoolData.name;
     this.appUsageService.increment();
+
+    // remove pupil data from local storage after setting them visually
+    const checkCode = pupilData.checkCode;
+    this.storageService.setItem('pupil', { checkCode });
   }
 
   async ngOnInit() {
@@ -69,9 +73,6 @@ export class LoginSuccessComponent implements OnInit, AfterViewInit, OnDestroy {
   }
 
   onClick() {
-    // remove pupil data from local storage after confirming identity
-    const checkCode = this.storageService.getItem('pupil').checkCode;
-    this.storageService.setItem('pupil', { checkCode });
     this.router.navigate(['check-start']);
   }
 

--- a/test/pupil/features/login_page.feature
+++ b/test/pupil/features/login_page.feature
@@ -26,7 +26,8 @@ Feature: Login page
   Scenario: Users can login with valid credentials
     Given I have logged in
     Then I should be taken to the confirmation page
-    Then I should see all the correct pupil details
+    And I should see all the correct pupil details
+    And pupil name is removed from local storage
 
   Scenario: Error is displayed when no details are entered
     Given I am on the sign in page


### PR DESCRIPTION
Ensure the pupil details (name, dob) are wiped as they are rendered on the login confirmation screen.