### PR TITLE
Bug/23637 Admin docker build gulp

### DIFF
--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -5,9 +5,9 @@ WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 COPY ./assets /usr/src/app
 COPY ./gulpfile.js /usr/src/app
+COPY . .
 RUN yarn install --ignore-engines
 
-COPY . .
 RUN ./node_modules/.bin/gulp build
 RUN yarn global add pm2
 

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -5,9 +5,10 @@ WORKDIR /usr/src/app
 COPY package.json /usr/src/app
 COPY ./assets /usr/src/app
 COPY ./gulpfile.js /usr/src/app
-COPY . .
+COPY ./config.js /usr/src/app
 RUN yarn install --ignore-engines
 
+COPY . .
 RUN ./node_modules/.bin/gulp build
 RUN yarn global add pm2
 


### PR DESCRIPTION
Added files to be copied before doing a yarn install

Because package.json had a postinstall that does gulp copy
and the files to be copied are not there, it was throwing errors