### PR TITLE
Fix `ng build --prod`

### DIFF
--- a/pupil-spa/src/app/practice-question/practice-question.component.ts
+++ b/pupil-spa/src/app/practice-question/practice-question.component.ts
@@ -56,7 +56,7 @@ export class PracticeQuestionComponent implements OnInit, AfterViewInit {
    * Set a reference to the config.
    * Contains access arrangements flags
    */
-  protected config: Config;
+  public config: Config;
 
   /**
    * The users answer made up of recorded numbers.


### PR DESCRIPTION
Fix an issue that was preventing Docker from building the pupil-spa.   The `config` var is referenced inside HTML, so needs to be public.

Let me know your thoughts.