### PR TITLE
move logging initialisation to before feature toggles are set

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -25,6 +25,8 @@ const csurf = require('csurf')
 const setupLogging = require('./helpers/logger')
 const setupBrowserSecurity = require('./helpers/browserSecurity')
 
+const app = express()
+setupLogging(app)
 azure.startInsightsIfConfigured()
 
 /**
@@ -69,10 +71,8 @@ const accessArrangements = require('./routes/access-arrangements')
 const checkWindow = require('./routes/check-window')
 
 if (process.env.NODE_ENV === 'development') piping({ ignore: [/test/, '/coverage/'] })
-const app = express()
 
 setupBrowserSecurity(app)
-setupLogging(app)
 
 // Use the feature toggle middleware to enable it in res.locals
 app.use(featureToggles.middleware)


### PR DESCRIPTION
we are loading the logger after we start using the logger, hence why no details appear in logs for feature toggle config.