### PR TITLE
Change env var for AI to official one & add env vars to SPA readme

### DIFF
--- a/pupil-spa/Dockerfile
+++ b/pupil-spa/Dockerfile
@@ -30,13 +30,13 @@ ARG runtime_config_url=/public/config.json
 # URL too, as long as it's accessible through http
 
 ARG ga_code
-ARG app_insights_code
+ARG appinsights_instrumentationkey
 ENV API_URL=$api_url
 ENV AUTH_URL=$auth_url
 ENV CHECK_STARTED_URL=$check_started_url
 ENV CHECK_SUBMISSION_URL=$check_submission_url
 ENV GA_CODE=$ga_code
-ENV APP_INSIGHTS_CODE=$app_insights_code
+ENV APPINSIGHTS_INSTRUMENTATIONKEY=$appinsights_instrumentationkey
 ENV RUNTIME_CONFIG_URL=$runtime_config_url
 
 RUN $(npm bin)/gulp setRuntimeConfigURL

--- a/pupil-spa/README.md
+++ b/pupil-spa/README.md
@@ -25,7 +25,7 @@ The following environment variables can be injected at start up...
 |`AUTH_URL`   |`url`   |Legacy mode only.  The full URL for pupil authentication   |
 |`CHECK_STARTED_URL`   |`url`   |Legacy mode only.  The full URL for check start notification   |
 |`CHECK_SUBMISSION_URL`   |`url`   |Legacy mode only.  The full URL for check submission   |
-|`PRODUCTION`   |`true|false`   |Production or debug mode   |
+|`PRODUCTION`   |`true / false`   |Production or debug mode   |
 |`APPINSIGHTS_INSTRUMENTATIONKEY`   |`uuid`   |The instrumentation key of the Application insights instance   |
 |`GA_CODE`   |`string`   |The unique identifier of the Google analytics instance   |
 |`CHECK_START_ERROR_DELAY`   |`integer`   |The delay in milliseconds between attempts to submit the check started notification   |

--- a/pupil-spa/README.md
+++ b/pupil-spa/README.md
@@ -14,6 +14,27 @@ Run `ng generate component component-name` to generate a new component. You can 
 
 Run `ng build` to build the project. The build artifacts will be stored in the `dist/` directory. Use the `-prod` flag for a production build.
 
+## Environment variables
+
+The following environment variables can be injected at start up...
+
+|Variable   |Type/Accepted Values   |Description   |
+|---|---|---|
+|`FEATURE_USE_HPA`   |`true|false`   |when `false` the SPA runs in legacy mode, and communicates directly with the admin app endpoints.  `true` will run in HPA mode, with a single endpoint for login and submission of data to various azure storage queues via HTTPS   |
+|`API_URL`   |`url`   |in HPA mode this should target the pupil API.  In legacy mode it should be the base URL of the admin app   |
+|`AUTH_URL`   |`url`   |Legacy mode only.  The full URL for pupil authentication   |
+|`CHECK_STARTED_URL`   |`url`   |Legacy mode only.  The full URL for check start notification   |
+|`CHECK_SUBMISSION_URL`   |`url`   |Legacy mode only.  The full URL for check submission   |
+|`PRODUCTION`   |`true|false`   |Production or debug mode   |
+|`APPINSIGHTS_INSTRUMENTATIONKEY`   |`uuid`   |The instrumentation key of the Application insights instance   |
+|`GA_CODE`   |`string`   |The unique identifier of the Google analytics instance   |
+|`CHECK_START_ERROR_DELAY`   |`integer`   |The delay in milliseconds between attempts to submit the check started notification   |
+|`CHECK_START_MAX_ATTEMPTS`   |`integer`   |The max number of attempts in submitting the check started notification   |
+|`CHECK_SUBMISSION_ERROR_DELAY`   |`integer`   |The delay in milliseconds between attempts to submit the completed check   |
+|`CHECK_SUBMISSION_MAX_ATTEMPTS`   |`integer`   |The max number of attempts in submitting the completed check   |
+|`SUBMISSION_PENDING_MIN_DISPLAY`   |`integer`   |The minimum amount of time in milliseconds that the completed check submission pending view should display for   |
+|`SUPPORT_NUMBER`   |`telephone number`   |The telephone number for helpdesk support   |
+
 ## Running unit tests
 
 Run `ng test` to execute the unit tests via [Karma](https://karma-runner.github.io).

--- a/pupil-spa/gen_config.sh
+++ b/pupil-spa/gen_config.sh
@@ -24,7 +24,7 @@ then
 else
     gaCodeParsed="\"$gaCode\""
 fi
-applicationInsightsCode=${APP_INSIGHTS_CODE:-"null"}
+applicationInsightsCode=${APPINSIGHTS_INSTRUMENTATIONKEY:-"null"}
 if [ $applicationInsightsCode == "null" ]
 then
     applicationInsightsCodeParsed="null"


### PR DESCRIPTION
- app insights uses `APPINSIGHTS_INSTRUMENTATIONKEY` in azure, so this will ensure smoother integration when done from the Azure Portal.
- added section to readme for env vars with table listing each one