### PR TITLE
bug/26617 fix parameter prefix for CORS in queue setup script

### DIFF
--- a/deploy/storage/create-items.sh
+++ b/deploy/storage/create-items.sh
@@ -14,7 +14,7 @@ storageAccountKey=$2
 allowedOrigins=$3
 
 # set the cors rule for the queues
-az storage cors add --methods POST --origins allowedOrigins --services q --account-name $storageAccountName --account-key $storageAccountKey
+az storage cors add --methods POST --origins $allowedOrigins --services q --account-name $storageAccountName --account-key $storageAccountKey
 
 declare -a queuenames=('check-started' 'check-complete' 'prepare-check' 'pupil-feedback' 'pupil-login' 'pupil-prefs' 'pupil-status')
 # create queues if they do not exist


### PR DESCRIPTION
the allowedOrigins parameter was not correctly prefixed with a dollar sign.