### PR TITLE
Feature/add pupil load test script

### DIFF
--- a/load-test/bin/generate-pupil-data.js
+++ b/load-test/bin/generate-pupil-data.js
@@ -2,7 +2,6 @@
 'use strict'
 
 // require('dotenv').config()
-const { performance } = require('perf_hooks');
 const winston = require('winston')
 const upnService = require('../../admin/services/upn.service')
 winston.level = 'info'
@@ -10,6 +9,7 @@ const moment = require('moment')
 
 const poolService = require('../../admin/services/data-access/sql.pool.service')
 const sqlService = require('../../admin/services/data-access/sql.service')
+const pupilCountPerSchool = 40
 
 async function main () {
   try {
@@ -20,8 +20,14 @@ async function main () {
       leaCode          
     from [mtc_admin].[school]`)
 
-    for (let school of schools) {
+    console.log(`Generating ${pupilCountPerSchool} pupils each for ${schools.length} schools`)
+    let c = 1;
+    for (const school of schools) {
       await insertPupils(school, 40)
+      c += 1
+      if (c % 1000 === 0) {
+        console.log(`${c} schools`)
+      }
     }
   } catch (error) {
     console.log(error.message)

--- a/load-test/bin/generate-pupil-data.js
+++ b/load-test/bin/generate-pupil-data.js
@@ -1,0 +1,81 @@
+#!/usr/bin/env node
+'use strict'
+
+// require('dotenv').config()
+const { performance } = require('perf_hooks');
+const winston = require('winston')
+const upnService = require('../../admin/services/upn.service')
+winston.level = 'info'
+const moment = require('moment')
+
+const poolService = require('../../admin/services/data-access/sql.pool.service')
+const sqlService = require('../../admin/services/data-access/sql.service')
+
+async function main () {
+  try {
+    const schools = await sqlService.query(`SELECT 
+      id, 
+      dfeNumber,
+      estabCode,
+      leaCode          
+    from [mtc_admin].[school]`)
+
+    for (let school of schools) {
+      await insertPupils(school, 40)
+    }
+  } catch (error) {
+    console.log(error.message)
+    throw error
+  }
+}
+
+main()
+  .then(() => {
+    poolService.drain()
+  })
+  .catch(e => {
+    console.warn(e)
+    poolService.drain()
+  })
+
+async function insertPupils (school, count) {
+  const insert = `INSERT INTO [mtc_admin].[pupil] (
+    dateOfBirth,
+    foreName,
+    gender,
+    lastName,
+    school_id,
+    upn
+  ) VALUES`
+  const pupilData = []
+  for (let i = 0; i < count; i++ ) {
+    pupilData.push([
+      `( '${randomDob()}'`,
+      `'Pupil'`,
+      `'M'`,
+      `'${count.toString()}'`,
+      school.id,
+      `'${genUPN(school.leaCode, school.estabCode, i)}')`,
+    ].join(' , '))
+  }
+  const sql = `${insert} ${pupilData.join(', \n')}`
+  return sqlService.modify(sql)
+}
+
+function randomDob () {
+  const rnd = Math.floor(Math.random() * (365 * 2) + 1)
+  const dob = moment().utc().subtract(9, 'years').subtract(rnd, 'days')
+  dob.hours(0).minute(0).second(0)
+  return dob.toISOString()
+}
+
+function genUPN (leaCode, estabCode, serial) {
+  try {
+    const upn = '' + leaCode.toString() + estabCode + (new Date().getFullYear().toString().substr(-2))
+      + serial.toString().padStart(3, '0')
+    const checkLetter = upnService.calculateCheckLetter(upn)
+    return checkLetter + upn
+  } catch (error) {
+    console.log(`Failed on: leaCode [${leaCode}] estab: [${estabCode}] serial: [${serial}]`)
+  }
+}


### PR DESCRIPTION
Add script to generate over 700K pupils (40 each school)

PR submitted as this may prove useful to me, and perhaps others.

```
load-test/bin/ > /usr/bin/time -p node generate-pupil-data.js
(node:96153) [DEP0064] DeprecationWarning: tls.createSecurePair() is deprecated. Please use tls.TLSSocket instead.
Generating 40 pupils each for 18605 schools
1000 schools
2000 schools
3000 schools
4000 schools
5000 schools
6000 schools
7000 schools
8000 schools
9000 schools
10000 schools
11000 schools
12000 schools
13000 schools
14000 schools
15000 schools
16000 schools
17000 schools
18000 schools
real       283.50
user        21.11
sys          1.47
load-test/bin/ > 
```