### PR TITLE
Fix cron expression that fails on Azure

### DIFF
--- a/functions/check-expiry/function.json
+++ b/functions/check-expiry/function.json
@@ -2,7 +2,7 @@
   "disabled": false,
   "bindings": [
     {
-      "schedule": "*/3 0-6,16-23 * * *",
+      "schedule": "30 */3 * * * *",
       "name": "checkExpiryTimer",
       "type": "timerTrigger",
       "direction": "in"


### PR DESCRIPTION
Runs every 3 minutes when the seconds are at 30 to avoid conflicts.

Works locally: 

<img width="953" alt="screen shot 2018-12-12 at 10 20 57" src="https://user-images.githubusercontent.com/13945069/49863187-a7470900-fdf7-11e8-9d97-869de9b824ee.png">
