### PR TITLE
Bug/27545 pupil not being highlighted when a restart has been applied

### DIFF
--- a/admin/assets/javascripts/table-sorting.js
+++ b/admin/assets/javascripts/table-sorting.js
@@ -53,7 +53,7 @@ $(function () {
     applySortClass: function (headerEl) {
       // Remove sort classes from headers
       var nodeList = document.querySelectorAll('thead tr th span')
-      for (var i=0; i<nodeList.length; i++) {
+      for (var i = 0; i < nodeList.length; i++) {
         nodeList[i].className = 'sort-icon'
       }
 
@@ -75,7 +75,7 @@ $(function () {
       // Listen for click events and perform sorting
       var thNodeList = document.querySelectorAll('th')
 
-      for (var i=0; i<thNodeList.length; i++) {
+      for (var i = 0; i < thNodeList.length; i++) {
         var th = thNodeList[i]
         window.GOVUK.tableSort.setUpClickHandler(th, i, tableId, config)
       }
@@ -93,9 +93,9 @@ $(function () {
           this.asc = this.asc !== undefined ? !this.asc : false,
           config)
         )
-        .forEach(function (tr) {
-          return tbody.appendChild(tr)
-        })
+          .forEach(function (tr) {
+            return tbody.appendChild(tr)
+          })
       })
     }
   }

--- a/admin/controllers/restart.js
+++ b/admin/controllers/restart.js
@@ -33,6 +33,7 @@ controller.getRestartOverview = async (req, res, next) => {
     return next(error)
   }
   let { hl } = req.query
+
   if (hl) {
     hl = hl.split(',').map(h => decodeURIComponent(h))
   }
@@ -119,15 +120,15 @@ controller.postSubmitRestartList = async (req, res, next) => {
       error: validationError
     })
   }
-  let submittedRestarts
+  let pupilsRestarted
   try {
-    submittedRestarts = await restartService.restart(pupilsList, restartReason, classDisruptionInfo, didNotCompleteInfo, restartFurtherInfo, req.user.id, req.user.schoolId)
+    pupilsRestarted = await restartService.restart(pupilsList, restartReason, classDisruptionInfo, didNotCompleteInfo, restartFurtherInfo, req.user.id, req.user.schoolId)
   } catch (error) {
     return next(error)
   }
-  const restartInfo = submittedRestarts.length < 2 ? 'Restart made for 1 pupil' : `Restarts made for ${submittedRestarts.length} pupils`
-  const restartIds = submittedRestarts && submittedRestarts.map(r => encodeURIComponent(r.insertId))
-  const ids = restartIds.join()
+  const restartInfo = pupilsRestarted.length < 2 ? 'Restart made for 1 pupil' : `Restarts made for ${pupilsRestarted.length} pupils`
+  const pupilUrlSlugs = pupilsRestarted && pupilsRestarted.map(p => encodeURIComponent(p.urlSlug))
+  const pupilsToHighlight = pupilUrlSlugs.join()
   req.flash('info', restartInfo)
 
   // Ask for these pupils to have their status updated
@@ -140,7 +141,7 @@ controller.postSubmitRestartList = async (req, res, next) => {
     throw error
   }
 
-  return res.redirect(`/restart/overview?hl=${ids}`)
+  return res.redirect(`/restart/overview?hl=${pupilsToHighlight}`)
 }
 
 controller.postDeleteRestart = async (req, res, next) => {

--- a/admin/services/pupil-register.service.js
+++ b/admin/services/pupil-register.service.js
@@ -119,8 +119,8 @@ const pupilRegisterService = {
     }
 
     if (pupilRestartId && !pupilRestartCheckId) {
-        // unconsumed restart
-        status = 'Restart'
+      // unconsumed restart
+      status = 'Restart'
     }
 
     return status

--- a/admin/services/restart-v2.service.js
+++ b/admin/services/restart-v2.service.js
@@ -24,6 +24,7 @@ module.exports.getPupilsEligibleForRestart = async function getPupilsEligibleFor
  * {
         id: record.id,
         pupilId: p.id,
+        pupilUrlSlug: p.urlSlug,
         reason: reason,
         status: record.status,
         foreName: p.foreName,

--- a/admin/services/restart.service.js
+++ b/admin/services/restart.service.js
@@ -99,7 +99,7 @@ restartService.restart = async (
     return pupilRestartDataService.sqlCreate(pupilRestartData)
   }))
   const pupilInfo = await pupilDataService.sqlFindByIds(pupilsList, schoolId)
-  return pupilInfo.map(p =>  { return { urlSlug: p.urlSlug } })
+  return pupilInfo.map(p => { return { urlSlug: p.urlSlug } })
 }
 
 /**

--- a/admin/services/restart.service.js
+++ b/admin/services/restart.service.js
@@ -86,7 +86,7 @@ restartService.restart = async (
     throw new Error(`One of the pupils is not eligible for a restart`)
   }
   const restartReasonId = await pupilRestartDataService.sqlFindRestartReasonByCode(restartReasonCode)
-  return Promise.all(pupilsList.map(async pupilId => {
+  await Promise.all(pupilsList.map(async pupilId => {
     const pupilRestartData = {
       pupil_id: pupilId,
       recordedByUser_id: userName,
@@ -98,6 +98,8 @@ restartService.restart = async (
     }
     return pupilRestartDataService.sqlCreate(pupilRestartData)
   }))
+  const pupilInfo = await pupilDataService.sqlFindByIds(pupilsList, schoolId)
+  return pupilInfo.map(p =>  { return { urlSlug: p.urlSlug } })
 }
 
 /**

--- a/admin/spec/back-end/service/restart.service.spec.js
+++ b/admin/spec/back-end/service/restart.service.spec.js
@@ -114,6 +114,7 @@ describe('restart.service', () => {
       spyOn(restartService, 'canAllPupilsRestart').and.returnValue(true)
       spyOn(pupilRestartDataService, 'sqlFindRestartReasonByCode').and.returnValue(2)
       spyOn(pupilRestartDataService, 'sqlCreate').and.returnValue({ 'ok': 1, 'n': 1 })
+      spyOn(pupilDataService, 'sqlFindByIds').and.returnValue([{ id: 1, urlSlug: 'anc-def' }])
       let results
       try {
         results = await restartService.restart([ pupilMock.id, pupilMock.id ], 'IT issues', '', '', '', '59c38bcf3cd57f97b7da2002', schoolId)
@@ -121,7 +122,7 @@ describe('restart.service', () => {
         expect(error).toBeUndefined()
       }
       expect(pupilRestartDataService.sqlCreate).toHaveBeenCalledTimes(2)
-      expect(results.length).toBe(2)
+      expect(results.length).toBe(1)
     })
     it('it should throw an error if the pupil cannot be restarted', async () => {
       const schoolId = 42

--- a/admin/views/restart/restart-overview.ejs
+++ b/admin/views/restart/restart-overview.ejs
@@ -81,15 +81,17 @@
             <tbody>
             <% restarts.forEach( (restart, index) => { %>
             <tr class="restart-pupil-name">
-                <td<% if (highlight && highlight.has(restart.urlSlug.toString())) { %> class="highlight-item"<% } %>>
-                    <span id="pupil-<%= restart.urlSlug %>">
-                    <%= restart.fullName %>
-                    </span>
-                    <% if (restart.showDoB) { %>
-                    <div class="font-greyed-out font-xsmall">
-                        Date of birth: <%= restart.dateOfBirth %>
+                <td<% if (highlight && highlight.has(restart.urlSlug)) { %> class="highlight-item"<% } %>>
+                    <div class="highlight-wrapper">
+                        <span id="pupil-<%= restart.urlSlug %>">
+                        <%= restart.fullName %>
+                        </span>
+                        <% if (restart.showDoB) { %>
+                            <div class="font-greyed-out font-xsmall">
+                                Date of birth: <%= restart.dateOfBirth %>
+                            </div>
+                        <% } %>
                     </div>
-                    <% } %>
                 </td>
                 <td class="restart-reason"><%= restart.reason %></td>
                 <% if (restart.status === 'Remove restart') {%>


### PR DESCRIPTION
* add a missing highlight wrapper class
* send pupil urlSlugs through to the controller rather than restart ids as the page is using pupil `urlSlugs` for item identification

![screen shot 2018-12-19 at 19 42 05](https://user-images.githubusercontent.com/13945069/50243843-30e17280-03c6-11e9-8e44-df613bc5d5c5.png)
