### PR TITLE
Redis as an express session provider

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -80,7 +80,9 @@ const accessArrangements = require('./routes/access-arrangements')
 const checkWindow = require('./routes/check-window')
 const checkForm = require('./routes/check-form')
 
-if (process.env.NODE_ENV === 'development') piping({ ignore: [/test/, '/coverage/'] })
+if (process.env.NODE_ENV === 'development') piping({
+  ignore: [/test/, '/coverage/']
+})
 
 setupBrowserSecurity(app)
 
@@ -125,10 +127,15 @@ let sessionStore
 
 if (config.Redis.Host) {
   const RedisStore = require('connect-redis')(session)
+  const redis = require('redis')
+  const client = redis.createClient(config.Redis.Port, config.Redis.Host, {
+    auth_pass: config.Redis.Key,
+    tls: {
+      servername: config.Redis.Host
+    }
+  })
   sessionStore = new RedisStore({
-    host: config.Redis.Host,
-    port: config.Redis.Port,
-    password: config.Redis.Password
+    client: client
   })
 } else {
   const TediousSessionStore = require('connect-tedious')(session)
@@ -196,8 +203,9 @@ passport.use(new CustomStrategy(
 
 // Passport with local strategy
 passport.use(
-  new LocalStrategy(
-    { passReqToCallback: true },
+  new LocalStrategy({
+      passReqToCallback: true
+    },
     require('./authentication/local-strategy')
   )
 )

--- a/admin/config.js
+++ b/admin/config.js
@@ -118,6 +118,6 @@ module.exports = {
   Redis: {
     Host: process.env.REDIS_HOST,
     Port: process.env.REDIS_PORT,
-    Password: process.env.REDIS_PASSWORD
+    Key: process.env.REDIS_KEY
   }
 }

--- a/admin/config.js
+++ b/admin/config.js
@@ -114,5 +114,10 @@ module.exports = {
       CollectDependencies: process.env.APPINSIGHTS_COLLECT_DEPS,
       CollectExceptions: process.env.APPINSIGHTS_COLLECT_EXCEPTIONS
     }
+  },
+  Redis: {
+    Host: process.env.REDIS_HOST,
+    Port: process.env.REDIS_PORT,
+    Password: process.env.REDIS_PASSWORD
   }
 }

--- a/admin/package.json
+++ b/admin/package.json
@@ -64,6 +64,7 @@
     "qrcode": "^1.0.0",
     "ramda": "^0.26.1",
     "random-number-csprng": "^1.0.2",
+    "redis": "^2.8.0",
     "serve-favicon": "^2.4.5",
     "tedious": "^3.0.1",
     "tedious-connection-pool": "^1.0.5",

--- a/admin/package.json
+++ b/admin/package.json
@@ -29,6 +29,7 @@
     "bcryptjs": "^2.4.3",
     "bluebird": "^3.5.1",
     "connect-flash": "^0.1.1",
+    "connect-redis": "^3.4.0",
     "connect-tedious": "^1.1.2",
     "cors": "^2.8.4",
     "csurf": "^1.9.0",

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -1327,6 +1327,14 @@ connect-flash@^0.1.1:
   resolved "https://registry.yarnpkg.com/connect-flash/-/connect-flash-0.1.1.tgz#d8630f26d95a7f851f9956b1e8cc6732f3b6aa30"
   integrity sha1-2GMPJtlaf4UfmVax6MxnMvO2qjA=
 
+connect-redis@^3.4.0:
+  version "3.4.0"
+  resolved "https://registry.yarnpkg.com/connect-redis/-/connect-redis-3.4.0.tgz#4040dd3755bddbf93478fb84937a74052c31b965"
+  integrity sha512-YKPSO9tLwzUr8jzhsGMdSJUxevWrDt0ggXRcTMb+mtnJ/vWGlWV7RC4VUMgqvZv3uTGDFye8Bf7d6No0oSVkOQ==
+  dependencies:
+    debug "^4.0.1"
+    redis "^2.8.0"
+
 connect-tedious@^1.1.2:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/connect-tedious/-/connect-tedious-1.1.2.tgz#c69dab52bc0b2e10c5d1cd79e4fbc7ef06999001"
@@ -1872,6 +1880,11 @@ dotenv@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-6.2.0.tgz#941c0410535d942c8becf28d3f357dbd9d476064"
   integrity sha512-HygQCKUBSFl8wKQZBSemMywRWcEDNidvNbjGVyZu3nbZ8qq9ubiPoGLMdRDpfSrpkkm9BXYFkpKxxFX38o/76w==
+
+double-ended-queue@^2.1.0-0:
+  version "2.1.0-0"
+  resolved "https://registry.yarnpkg.com/double-ended-queue/-/double-ended-queue-2.1.0-0.tgz#103d3527fd31528f40188130c841efdd78264e5c"
+  integrity sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=
 
 duplexer2@0.0.2:
   version "0.0.2"
@@ -6237,6 +6250,25 @@ redent@^1.0.0:
   dependencies:
     indent-string "^2.1.0"
     strip-indent "^1.0.1"
+
+redis-commands@^1.2.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/redis-commands/-/redis-commands-1.4.0.tgz#52f9cf99153efcce56a8f86af986bd04e988602f"
+  integrity sha512-cu8EF+MtkwI4DLIT0x9P8qNTLFhQD4jLfxLR0cCNkeGzs87FN6879JOJwNQR/1zD7aSYNbU0hgsV9zGY71Itvw==
+
+redis-parser@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/redis-parser/-/redis-parser-2.6.0.tgz#52ed09dacac108f1a631c07e9b69941e7a19504b"
+  integrity sha1-Uu0J2srBCPGmMcB+m2mUHnoZUEs=
+
+redis@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/redis/-/redis-2.8.0.tgz#202288e3f58c49f6079d97af7a10e1303ae14b02"
+  integrity sha512-M1OkonEQwtRmZv4tEWF2VgpG0JWJ8Fv1PhlgT5+B+uNq2cA3Rt1Yt/ryoR+vQNOQcIEgdCdfH0jr3bDpihAw1A==
+  dependencies:
+    double-ended-queue "^2.1.0-0"
+    redis-commands "^1.2.0"
+    redis-parser "^2.6.0"
 
 referrer-policy@1.1.0:
   version "1.1.0"


### PR DESCRIPTION
SQL Server is becoming a bottleneck at high load.

This moves the session store dependency away to redis.

Merging to load test support branch, *not* master, for load testing.