### PR TITLE
bump docker images to lower vulnerabilities

### DIFF
--- a/admin-assets/Dockerfile
+++ b/admin-assets/Dockerfile
@@ -1,5 +1,5 @@
 
-FROM nginx:1.13.3-alpine
+FROM nginx:1.14.1-alpine
 
 ## Copy our default nginx config
 COPY nginx/default.conf /etc/nginx/conf.d/

--- a/admin/Dockerfile
+++ b/admin/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.0
+FROM node:8.11.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/pupil-api/Dockerfile
+++ b/pupil-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8.11.0
+FROM node:8.11.1
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app

--- a/pupil-spa/Dockerfile
+++ b/pupil-spa/Dockerfile
@@ -49,7 +49,7 @@ RUN sh gen_config.sh && mv config.json dist/public
 
 ### STAGE 2: Setup ###
 
-FROM nginx:1.13.3-alpine
+FROM nginx:1.14.1-alpine
 
 # defer until SSL integrated, need to get package
 # RUN openssl dhparam -out /etc/nginx/ssl/dhparam.pem 2048


### PR DESCRIPTION
Bump docker base images as far up as feasibly possible.

admin & auth unable to move to node 10 until we have resolved compatibility issues