### PR TITLE
31718 - Added timer reset on sign out, so it's ready for next sign in

### DIFF
--- a/pupil-spa/src/app/check/check.component.ts
+++ b/pupil-spa/src/app/check/check.component.ts
@@ -94,6 +94,8 @@ export class CheckComponent implements OnInit {
         numQuestions: this.questionService.getNumberOfQuestions(),
         numCompleted: this.questionService.getCurrentQuestionNumber()
       });
+      // stop the check timer on sign out, so it's reset for the next log-in
+      this.timerService.stopCheckTimer();
       this.router.navigate(['/out-of-time']);
   });
 


### PR DESCRIPTION
  - For pupils with AA next button, this was using the same
    timer between sessions. So for the second person it was at 0