### PR TITLE
Added migration to restore "(reason required)" text to next button AA

### DIFF
--- a/admin/data/sql/migrations/20190417091050.do.add-reason-required-to-next-button-aa.sql
+++ b/admin/data/sql/migrations/20190417091050.do.add-reason-required-to-next-button-aa.sql
@@ -1,0 +1,3 @@
+UPDATE [mtc_admin].[accessArrangements]
+SET description='''Next'' button between questions (reason required)'
+WHERE code='NBQ'

--- a/admin/data/sql/migrations/20190417091050.undo.add-reason-required-to-next-button-aa.sql
+++ b/admin/data/sql/migrations/20190417091050.undo.add-reason-required-to-next-button-aa.sql
@@ -1,0 +1,3 @@
+UPDATE [mtc_admin].[accessArrangements]
+SET description='''Next'' button between questions'
+WHERE code='NBQ'


### PR DESCRIPTION
  - It was added by modifying a migration, meaning it would be missing
    in existing schema