### PR TITLE
default to empty object when no azure connectivity

### DIFF
--- a/admin/services/data-access/azure-blob.data.service.js
+++ b/admin/services/data-access/azure-blob.data.service.js
@@ -8,6 +8,8 @@ let blobService
 
 if (config.AZURE_STORAGE_CONNECTION_STRING) {
   blobService = azureStorage.createBlobService()
+} else {
+  blobService = {}
 }
 
 bluebird.promisifyAll(blobService, {


### PR DESCRIPTION
promisification of azure blob storage service fails if no azure connection string available.