### PR TITLE
Bug/32245 Duplicate records on pin generated list

### DIFF
--- a/admin/data/sql/migrations/20190501174958.do.alter-vew-pupils-with-active-familiarisation-pins.sql
+++ b/admin/data/sql/migrations/20190501174958.do.alter-vew-pupils-with-active-familiarisation-pins.sql
@@ -1,0 +1,25 @@
+ALTER VIEW [mtc_admin].[vewPupilsWithActiveFamiliarisationPins] AS
+  SELECT
+         p.id,
+         p.foreName,
+         p.lastName,
+         p.middleNames,
+         p.dateOfBirth,
+         p.urlSlug,
+         p.school_id,
+         pin.val as pin,
+         cp.pinExpiresAt,
+         g.group_id
+  FROM [mtc_admin].[pupil] p
+         INNER JOIN [mtc_admin].[school] s ON (p.school_id = s.id)
+         LEFT JOIN  [mtc_admin].[pupilGroup] g ON (g.pupil_id = p.id)
+         INNER JOIN [mtc_admin].[check] chk ON (chk.pupil_id = p.id)
+         INNER JOIN [mtc_admin].[checkStatus] chkStatus ON (chk.checkStatus_id = chkStatus.id)
+         INNER JOIN [mtc_admin].[checkPin] cp ON (chk.id = cp.check_id)
+         INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+         LEFT JOIN [mtc_admin].[pupilAttendance] paa ON paa.pupil_id = p.id AND paa.isDeleted = 0
+  WHERE  cp.pinExpiresAt > GETUTCDATE()
+    AND  chkStatus.code IN ('NEW', 'STD', 'COL')
+    AND  chk.isLiveCheck = 0
+    AND  paa.id IS NULL
+

--- a/admin/data/sql/migrations/20190501174958.undo.alter-vew-pupils-with-active-familiarisation-pins.sql
+++ b/admin/data/sql/migrations/20190501174958.undo.alter-vew-pupils-with-active-familiarisation-pins.sql
@@ -1,0 +1,25 @@
+ALTER VIEW [mtc_admin].[vewPupilsWithActiveFamiliarisationPins] AS
+  SELECT
+         p.id,
+         p.foreName,
+         p.lastName,
+         p.middleNames,
+         p.dateOfBirth,
+         p.urlSlug,
+         p.school_id,
+         pin.val as pin,
+         cp.pinExpiresAt,
+         g.group_id
+  FROM [mtc_admin].[pupil] p
+         INNER JOIN [mtc_admin].[school] s ON (p.school_id = s.id)
+         LEFT JOIN  [mtc_admin].[pupilGroup] g ON (g.pupil_id = p.id)
+         INNER JOIN [mtc_admin].[check] chk ON (chk.pupil_id = p.id)
+         INNER JOIN [mtc_admin].[checkStatus] chkStatus ON (chk.checkStatus_id = chkStatus.id)
+         INNER JOIN [mtc_admin].[checkPin] cp ON (chk.id = cp.check_id)
+         INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+         LEFT JOIN [mtc_admin].[pupilAttendance] paa ON paa.pupil_id = p.id
+  WHERE  cp.pinExpiresAt > GETUTCDATE()
+    AND  chkStatus.code IN ('NEW', 'STD', 'COL')
+    AND  chk.isLiveCheck = 0
+    AND (paa.id IS NULL OR paa.isDeleted = 1)
+

--- a/admin/data/sql/migrations/20190501175006.do.alter-vew-pupils-with-active-live-pins.sql
+++ b/admin/data/sql/migrations/20190501175006.do.alter-vew-pupils-with-active-live-pins.sql
@@ -1,0 +1,24 @@
+ALTER VIEW [mtc_admin].[vewPupilsWithActiveLivePins] AS
+  SELECT
+         p.id,
+         p.foreName,
+         p.lastName,
+         p.middleNames,
+         p.dateOfBirth,
+         p.urlSlug,
+         p.school_id,
+         pin.val as pin,
+         cp.pinExpiresAt,
+         g.group_id
+  FROM [mtc_admin].[pupil] p
+         INNER JOIN [mtc_admin].[school] s ON p.school_id = s.id
+         LEFT JOIN  [mtc_admin].[pupilGroup] g ON g.pupil_id = p.id
+         INNER JOIN [mtc_admin].[check] chk ON chk.pupil_id = p.id
+         INNER JOIN [mtc_admin].[checkStatus] chkStatus ON chk.checkStatus_id = chkStatus.id
+         INNER JOIN [mtc_admin].[checkPin] cp ON (chk.id = cp.check_id)
+         INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+         LEFT JOIN [mtc_admin].[pupilAttendance] paa ON paa.pupil_id = p.id AND paa.isDeleted = 0
+  WHERE  cp.pinExpiresAt > GETUTCDATE()
+    AND  chkStatus.code IN ('NEW', 'COL')
+    AND  chk.isLiveCheck = 1
+    AND  paa.id IS NULL

--- a/admin/data/sql/migrations/20190501175006.undo.alter-vew-pupils-with-active-live-pins.sql
+++ b/admin/data/sql/migrations/20190501175006.undo.alter-vew-pupils-with-active-live-pins.sql
@@ -1,0 +1,24 @@
+ALTER VIEW [mtc_admin].[vewPupilsWithActiveLivePins] AS
+  SELECT
+         p.id,
+         p.foreName,
+         p.lastName,
+         p.middleNames,
+         p.dateOfBirth,
+         p.urlSlug,
+         p.school_id,
+         pin.val as pin,
+         cp.pinExpiresAt,
+         g.group_id
+  FROM [mtc_admin].[pupil] p
+         INNER JOIN [mtc_admin].[school] s ON p.school_id = s.id
+         LEFT JOIN  [mtc_admin].[pupilGroup] g ON g.pupil_id = p.id
+         INNER JOIN [mtc_admin].[check] chk ON chk.pupil_id = p.id
+         INNER JOIN [mtc_admin].[checkStatus] chkStatus ON chk.checkStatus_id = chkStatus.id
+         INNER JOIN [mtc_admin].[checkPin] cp ON (chk.id = cp.check_id)
+         INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+         LEFT JOIN [mtc_admin].[pupilAttendance] paa ON paa.pupil_id = p.id
+  WHERE  cp.pinExpiresAt > GETUTCDATE()
+    AND  chkStatus.code IN ('NEW', 'COL')
+    AND  chk.isLiveCheck = 1
+    AND (paa.id IS NULL OR paa.isDeleted = 1)


### PR DESCRIPTION
Avoid duplicate active pupil pin records appearing by joining only non deleted pupil attendance records
