### PR TITLE
drop obsolete tables and columns

### DIFF
--- a/admin/data/sql/migrations/20190517144520.do.drop-check.data.sql
+++ b/admin/data/sql/migrations/20190517144520.do.drop-check.data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [mtc_admin].[check]
+  DROP COLUMN [data]

--- a/admin/data/sql/migrations/20190517144520.undo.drop-check.data.sql
+++ b/admin/data/sql/migrations/20190517144520.undo.drop-check.data.sql
@@ -1,2 +1,2 @@
 ALTER TABLE [mtc_admin].[check]
-  ADD COLUMN data nvarchar(max)
+  ADD data nvarchar(max)

--- a/admin/data/sql/migrations/20190517144520.undo.drop-check.data.sql
+++ b/admin/data/sql/migrations/20190517144520.undo.drop-check.data.sql
@@ -1,0 +1,2 @@
+ALTER TABLE [mtc_admin].[check]
+  ADD COLUMN data nvarchar(max)

--- a/admin/data/sql/migrations/20190517144729.do.drop-sessions.sql
+++ b/admin/data/sql/migrations/20190517144729.do.drop-sessions.sql
@@ -1,0 +1,1 @@
+DROP TABLE [mtc_admin].[sessions]

--- a/admin/data/sql/migrations/20190517144729.undo.drop-sessions.sql
+++ b/admin/data/sql/migrations/20190517144729.undo.drop-sessions.sql
@@ -1,0 +1,8 @@
+create table mtc_admin.sessions
+(
+	sid varchar(255) not null
+		constraint pk_sessions
+			primary key,
+	expires datetimeoffset not null,
+	sess nvarchar(max)
+)

--- a/admin/data/sql/migrations/20190517144735.do.drop-pupillogonevent.sql
+++ b/admin/data/sql/migrations/20190517144735.do.drop-pupillogonevent.sql
@@ -1,0 +1,1 @@
+DROP TABLE [mtc_admin].[pupilLogonEvent]

--- a/admin/data/sql/migrations/20190517144735.undo.drop-pupillogonevent.sql
+++ b/admin/data/sql/migrations/20190517144735.undo.drop-pupillogonevent.sql
@@ -1,0 +1,16 @@
+create table mtc_admin.pupilLogonEvent
+(
+	id int identity
+		primary key,
+	createdAt datetimeoffset(3) default getutcdate() not null,
+	updatedAt datetimeoffset(3) default getutcdate() not null,
+	version timestamp not null,
+	pupil_id int
+		constraint FK_pupilLogonEvent_pupil_id
+			references mtc_admin.pupil,
+	isAuthenticated bit not null,
+	pupilPin nvarchar(50) not null,
+	schoolPin nvarchar(50) not null,
+	httpStatusCode smallint,
+	httpErrorMessage nvarchar(max)
+)

--- a/admin/data/sql/migrations/20190517145506.do.drop-pupilstatuscode-trigger.sql
+++ b/admin/data/sql/migrations/20190517145506.do.drop-pupilstatuscode-trigger.sql
@@ -1,0 +1,1 @@
+DROP TRIGGER [mtc_admin].[pupilStatusCodeUpdatedAtTrigger]

--- a/admin/data/sql/migrations/20190517145506.undo.drop-pupilstatuscode-trigger.sql
+++ b/admin/data/sql/migrations/20190517145506.undo.drop-pupilstatuscode-trigger.sql
@@ -1,0 +1,11 @@
+
+CREATE TRIGGER [mtc_admin].[pupilStatusCodeUpdatedAtTrigger]
+ON [mtc_admin].[pupilStatusCode]
+FOR UPDATE
+AS
+BEGIN
+    UPDATE [mtc_admin].[pupilStatusCode]
+    SET updatedAt = GETUTCDATE()
+    FROM inserted
+    WHERE [pupilStatusCode].id = inserted.id
+END

--- a/admin/data/sql/migrations/20190517145510.do.drop-pupilstatuscode-table.sql
+++ b/admin/data/sql/migrations/20190517145510.do.drop-pupilstatuscode-table.sql
@@ -1,0 +1,1 @@
+DROP TABLE [mtc_admin].[pupilStatusCode]

--- a/admin/data/sql/migrations/20190517145510.undo.drop-pupilstatuscode-table.sql
+++ b/admin/data/sql/migrations/20190517145510.undo.drop-pupilstatuscode-table.sql
@@ -1,0 +1,13 @@
+create table mtc_admin.pupilStatusCode
+(
+	id int identity
+		constraint PK_pupilStatusCode
+			primary key,
+	createdAt datetimeoffset(3) default getutcdate() not null,
+	updatedAt datetimeoffset(3) default getutcdate() not null,
+	version timestamp not null,
+	description nvarchar(50) not null,
+	code char(3) not null
+		constraint pupilStatusCode_code_uindex
+			unique
+)


### PR DESCRIPTION
- pupilStatusCode table
- pupilLogonEvent table
- sessions table
- check.data column

note: pupilLogonEvent is append only so the trigger should not have been there.  This has been omitted from the undo script.