### PR TITLE
bug/33210-fix pupil spa CSP policy for app insights

### DIFF
--- a/pupil-spa/nginx/default.conf
+++ b/pupil-spa/nginx/default.conf
@@ -91,7 +91,7 @@ server {
   # I need to change our application code so we can increase security by disabling 'unsafe-inline'
   # directives for css and js(if you have inline css or js, you will need to keep it too).
   # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://*.msecnd.net:*; img-src 'self' data: https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'none'; object-src 'none'; connect-src *; media-src data:";
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://*.msecnd.net:*; img-src 'self' data: https://www.google-analytics.com https://*.msecnd.net:*; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'none'; object-src 'none'; connect-src *; media-src data:";
 
   # prevents DNS prefetching https://helmetjs.github.io/docs/dns-prefetch-control/
   add_header X-DNS-Prefetch-Control off;

--- a/pupil-spa/nginx/default.conf
+++ b/pupil-spa/nginx/default.conf
@@ -91,7 +91,7 @@ server {
   # I need to change our application code so we can increase security by disabling 'unsafe-inline'
   # directives for css and js(if you have inline css or js, you will need to keep it too).
   # more: http://www.html5rocks.com/en/tutorials/security/content-security-policy/#inline-code-considered-harmful
-  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com; img-src 'self' data: https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'none'; object-src 'none'; connect-src *; media-src data:";
+  add_header Content-Security-Policy "default-src 'self'; script-src 'self' 'unsafe-inline' https://www.google-analytics.com https://*.msecnd.net:*; img-src 'self' data: https://www.google-analytics.com; style-src 'self' 'unsafe-inline'; font-src 'self' data:; frame-src 'none'; object-src 'none'; connect-src *; media-src data:";
 
   # prevents DNS prefetching https://helmetjs.github.io/docs/dns-prefetch-control/
   add_header X-DNS-Prefetch-Control off;


### PR DESCRIPTION
add additional CSP rule to NGINX to allow app insights tracking script