### PR TITLE
Spike/32415 split pupil status

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -50,6 +50,7 @@ function sleep (ms) {
   try {
     logger.debug('Attempting to initialise the connection pool')
     await sqlService.initPool()
+    await sqlService.startupCacheTables()
   } catch (error) {
     logger.alert('Failed to connect to the database', error)
     // The initial probe connection was not able to connect: the DB is not available.  This will cause all

--- a/admin/data/sql/migrations/20190520110152.do.create-pupil-status-link.sql
+++ b/admin/data/sql/migrations/20190520110152.do.create-pupil-status-link.sql
@@ -11,5 +11,11 @@ CREATE TABLE [mtc_admin].[pupilStatusLink] (
       IGNORE_DUP_KEY = OFF,
       ALLOW_ROW_LOCKS = ON,
       ALLOW_PAGE_LOCKS = ON
-    )
+    ),
+  CONSTRAINT [FK_pupilStatusLink_pupilStatus_id_pupilStatus_id]
+    FOREIGN KEY (pupilStatus_id)
+    REFERENCES [mtc_admin].[pupilStatus] (id),
+  CONSTRAINT [FK_pupilStatusLink_pupil_id_pupil_id]
+    FOREIGN KEY (pupil_id)
+    REFERENCES [mtc_admin].[pupil] (id)
 )

--- a/admin/data/sql/migrations/20190520110152.do.create-pupil-status-link.sql
+++ b/admin/data/sql/migrations/20190520110152.do.create-pupil-status-link.sql
@@ -1,0 +1,15 @@
+CREATE TABLE [mtc_admin].[pupilStatusLink] (
+  id int IDENTITY (1,1) NOT NULL,
+  pupil_id [int] NOT NULL,
+  pupilStatus_id [int] NOT NULL,
+  createdAt datetimeoffset(3) NOT NULL DEFAULT GETUTCDATE(),
+  updatedAt datetimeoffset(3) NOT NULL DEFAULT GETUTCDATE(),
+  CONSTRAINT [PK_pupilStatusLink] PRIMARY KEY CLUSTERED ([id] ASC)
+    WITH (
+      PAD_INDEX = OFF,
+      STATISTICS_NORECOMPUTE = OFF,
+      IGNORE_DUP_KEY = OFF,
+      ALLOW_ROW_LOCKS = ON,
+      ALLOW_PAGE_LOCKS = ON
+    )
+)

--- a/admin/data/sql/migrations/20190520110152.undo.create-pupil-status-link.sql
+++ b/admin/data/sql/migrations/20190520110152.undo.create-pupil-status-link.sql
@@ -1,0 +1,1 @@
+DROP TABLE [mtc_admin].[pupilStatusLink]

--- a/admin/data/sql/migrations/20190522085040.do.alter-vewpupilseligiblefortryitoutpin.sql
+++ b/admin/data/sql/migrations/20190522085040.do.alter-vewpupilseligiblefortryitoutpin.sql
@@ -1,0 +1,26 @@
+ALTER VIEW [mtc_admin].vewPupilsEligibleForTryItOutPin AS
+  SELECT
+    p.id,
+    p.foreName,
+    p.middleNames,
+    p.lastName,
+    p.dateOfBirth,
+    p.school_id,
+    g.group_id,
+    p.urlSlug
+  FROM [mtc_admin].[pupil] p
+  LEFT JOIN [mtc_admin].[pupilAttendance] pa ON (p.id = pa.pupil_id and pa.isDeleted = 0)
+  LEFT JOIN [mtc_admin].[attendanceCode] ac ON (pa.attendanceCode_id = ac.id )
+  LEFT JOIN [mtc_admin].[pupilGroup] g ON (g.pupil_id = p.id)
+  LEFT JOIN [mtc_admin].[pupilStatusLink] psl ON p.id = psl.pupil_id
+  INNER JOIN [mtc_admin].[pupilStatus] ps ON ISNULL(psl.pupilStatus_id, 1) = ps.id
+  LEFT JOIN [mtc_admin].[check] AS chk ON p.id = chk.pupil_id AND chk.isLiveCheck = 0
+  LEFT JOIN [mtc_admin].[checkStatus] AS chkStatus ON chk.checkStatus_id = chkStatus.id AND chkStatus.code IN ('NEW', 'STD', 'COL')
+  WHERE
+    -- include all pupils except those who are marked as not taking check because they left school
+    (ac.id IS NULL OR ac.code <> 'LEFTT')
+  AND ps.code IN ('UNALLOC',
+                  'ALLOC',
+                  'LOGGED_IN')
+    -- Exclude pupils who already have an active familiarisation check
+  AND chkStatus.id IS NULL

--- a/admin/data/sql/migrations/20190522085040.undo.alter-vewpupilseligiblefortryitoutpin.sql
+++ b/admin/data/sql/migrations/20190522085040.undo.alter-vewpupilseligiblefortryitoutpin.sql
@@ -1,0 +1,31 @@
+ALTER VIEW [mtc_admin].vewPupilsEligibleForTryItOutPin AS
+  SELECT
+    p.id,
+    p.foreName,
+    p.middleNames,
+    p.lastName,
+    p.dateOfBirth,
+    p.school_id,
+    g.group_id,
+    p.urlSlug
+  FROM [mtc_admin].[pupil] p
+  LEFT JOIN [mtc_admin].[pupilAttendance] pa ON (p.id = pa.pupil_id and pa.isDeleted = 0)
+  LEFT JOIN [mtc_admin].[attendanceCode] ac ON (pa.attendanceCode_id = ac.id )
+  LEFT JOIN  [mtc_admin].[pupilGroup] g ON (g.pupil_id = p.id)
+  INNER JOIN [mtc_admin].[pupilStatus] ps ON (p.pupilStatus_id = ps.id)
+  WHERE
+    -- include all pupils except those who are marked as not taking check because they left school
+    (ac.id IS NULL OR ac.code <> 'LEFTT')
+  AND ps.code IN ('UNALLOC',
+                  'ALLOC',
+                  'LOGGED_IN')
+    -- Exclude pupils who already have an active familiarisation check
+  AND p.id NOT IN (
+                  SELECT p2.id
+                  FROM [mtc_admin].[pupil] p2
+                  LEFT JOIN [mtc_admin].[check] AS chk ON (p.id = chk.pupil_id)
+                  LEFT JOIN [mtc_admin].[checkStatus] AS chkStatus ON (chk.checkStatus_id = chkStatus.id)
+                  WHERE chk.isLiveCheck = 0
+                  AND chkStatus.code IN ('NEW', 'STD', 'COL')
+                  AND p2.school_id = p.school_id
+                  )

--- a/admin/services/data-access/group.data.service.js
+++ b/admin/services/data-access/group.data.service.js
@@ -248,7 +248,8 @@ groupDataService.sqlFindPupils = async (schoolId, groupId) => {
 
   sql += ') ORDER BY group_id DESC, lastName ASC, foreName ASC, middleNames ASC, dateOfBirth ASC'
 
-  return sqlService.query(sql, params)
+  const pupils = await sqlService.query(sql, params)
+  return sqlService.addPupilStatuses(pupils)
 }
 
 /**

--- a/admin/services/data-access/pupil-access-arrangements.data.service.js
+++ b/admin/services/data-access/pupil-access-arrangements.data.service.js
@@ -156,8 +156,10 @@ pupilAccessArrangementsDataService.sqFindPupilsWithAccessArrangements = async (d
       FROM ${sqlService.adminSchema}.pupilAccessArrangements paa
         INNER JOIN ${sqlService.adminSchema}.pupil p
           ON paa.pupil_id = p.id
+        INNER JOIN ${sqlService.adminSchema}.pupilStatusLink psl
+          ON psl.pupil_id = p.id
         INNER JOIN ${sqlService.adminSchema}.pupilStatus ps
-         ON ps.id = p.pupilStatus_id
+         ON ps.id = ISNULL(psl.pupilStatus_id, 1)
         INNER JOIN ${sqlService.adminSchema}.school s
           ON p.school_id = s.id
         INNER JOIN ${sqlService.adminSchema}.accessArrangements aa
@@ -200,8 +202,10 @@ pupilAccessArrangementsDataService.sqlFindEligiblePupilsByDfeNumber = async (dfe
       FROM ${sqlService.adminSchema}.pupil p
       INNER JOIN ${sqlService.adminSchema}.school s
         ON p.school_id = s.id
+      INNER JOIN ${sqlService.adminSchema}.pupilStatusLink psl
+        ON psl.pupil_id = p.id
       INNER JOIN ${sqlService.adminSchema}.pupilStatus ps
-         ON ps.id = p.pupilStatus_id
+       ON ps.id = ISNULL(psl.pupilStatus_id, 1)
       LEFT JOIN ${sqlService.adminSchema}.pupilAttendance pa
         ON pa.pupil_id = p.id AND pa.isDeleted = 0
       LEFT JOIN (

--- a/admin/services/data-access/pupil-register.data.service.js
+++ b/admin/services/data-access/pupil-register.data.service.js
@@ -15,7 +15,8 @@ const service = {
       { name: 'schoolId', value: schoolId, type: TYPES.Int }
     ]
 
-    return sqlService.query(sql, params)
+    const pupils = await sqlService.query(sql, params)
+    return sqlService.addPupilStatuses(pupils, 'pupilId', 'code', 'longCode')
   },
 
   /**

--- a/admin/services/data-access/pupil-register.data.service.js
+++ b/admin/services/data-access/pupil-register.data.service.js
@@ -16,7 +16,7 @@ const service = {
     ]
 
     const pupils = await sqlService.query(sql, params)
-    return sqlService.addPupilStatuses(pupils, 'pupilId', 'pupilStatusCode', 'longCode')
+    return sqlService.addPupilStatuses(pupils, 'pupilId', { pupilStatusCode: 'longCode' })
   },
 
   /**

--- a/admin/services/data-access/pupil-register.data.service.js
+++ b/admin/services/data-access/pupil-register.data.service.js
@@ -16,7 +16,7 @@ const service = {
     ]
 
     const pupils = await sqlService.query(sql, params)
-    return sqlService.addPupilStatuses(pupils, 'pupilId', 'code', 'longCode')
+    return sqlService.addPupilStatuses(pupils, 'pupilId', 'pupilStatusCode', 'longCode')
   },
 
   /**

--- a/admin/services/data-access/pupil.data.service.js
+++ b/admin/services/data-access/pupil.data.service.js
@@ -25,7 +25,8 @@ pupilDataService.sqlFindPupilsByDfeNumber = async function (dfeNumber) {
       WHERE s.dfeNumber = @dfeNumber
       ORDER BY lastName asc      
     `
-  return sqlService.query(sql, [paramDfeNumber])
+  const pupils = await sqlService.query(sql, [paramDfeNumber])
+  return sqlService.addPupilStatuses(pupils)
 }
 
 /**
@@ -90,7 +91,8 @@ pupilDataService.sqlFindOneBySlug = async function (urlSlug, schoolId) {
       WHERE urlSlug = @urlSlug
       AND school_id = @schoolId  
     `
-  const results = await sqlService.query(sql, params)
+  let results = await sqlService.query(sql, params)
+  results = await sqlService.addPupilStatuses(results)
   return R.head(results)
 }
 
@@ -115,7 +117,8 @@ pupilDataService.sqlFindOneBySlugWithAgeReason = async function (urlSlug, school
       WHERE p.urlSlug = @urlSlug
       AND p.school_id = @schoolId 
     `
-  const results = await sqlService.query(sql, params)
+  let results = await sqlService.query(sql, params)
+  results = await sqlService.addPupilStatuses(results)
   return R.head(results)
 }
 
@@ -131,7 +134,8 @@ pupilDataService.sqlFindOneBySlugAndSchool = async function (urlSlug, dfeNumber)
       WHERE p.urlSlug = @urlSlug  
       AND   s.dfeNumber = @dfeNumber
     `
-  const results = await sqlService.query(sql, [paramSlug, paramDfeNumber])
+  let results = await sqlService.query(sql, [paramSlug, paramDfeNumber])
+  results = await sqlService.addPupilStatuses(results)
   return R.head(results)
 }
 
@@ -195,7 +199,8 @@ pupilDataService.sqlFindOneById = async (id) => {
       FROM ${sqlService.adminSchema}.${table}
       WHERE id = @id    
     `
-  const results = await sqlService.query(sql, [param])
+  let results = await sqlService.query(sql, [param])
+  results = await sqlService.addPupilStatuses(results)
   return R.head(results)
 }
 
@@ -241,7 +246,8 @@ pupilDataService.sqlFindOneWithAttendanceReasonsBySlugAndSchool = async (urlSlug
         ON pg.pupil_id = p.id 
       WHERE p.urlSlug = @urlSlug and school_id = @schoolId 
     `
-  const results = await sqlService.query(sql, [paramPupil, paramSchool])
+  let results = await sqlService.query(sql, [paramPupil, paramSchool])
+  results = await sqlService.addPupilStatuses(results, 'id', { pupilStatus_id: 'id', code: 'longCode' })
   return R.head(results)
 }
 

--- a/admin/services/data-access/pupil.data.service.js
+++ b/admin/services/data-access/pupil.data.service.js
@@ -311,7 +311,8 @@ pupilDataService.sqlFindPupilsWithActivePins = async (dfeNumber, pinEnv) => {
   AND p.pinExpiresAt > GETUTCDATE()
   ORDER BY p.lastName ASC, p.foreName ASC, p.middleNames ASC, dateOfBirth ASC
   `
-  return sqlService.query(sql, [paramDfeNumber])
+  const pupils = await sqlService.query(sql, [paramDfeNumber])
+  return sqlService.addPupilStatuses(pupils)
 }
 
 /**
@@ -337,7 +338,8 @@ pupilDataService.sqlFindPupilsByUrlSlug = async (slugs, schoolId) => {
     'AND school_id = @schoolId'
   params.push({ name: 'schoolId', type: TYPES.Int, value: schoolId })
   const sql = [select, whereClause].join(' ')
-  return sqlService.query(sql, params)
+  const pupils = await sqlService.query(sql, params)
+  return sqlService.addPupilStatuses(pupils)
 }
 
 /**
@@ -364,7 +366,8 @@ pupilDataService.sqlFindByIds = async (ids, schoolId) => {
   params.push({ name: 'schoolId', type: TYPES.Int, value: schoolId })
   const orderClause = 'ORDER BY lastName ASC, foreName ASC, middleNames ASC, dateOfBirth ASC'
   const sql = [select, whereClause, orderClause].join(' ')
-  return sqlService.query(sql, params)
+  const pupils = await sqlService.query(sql, params)
+  return sqlService.addPupilStatuses(pupils)
 }
 
 /**
@@ -483,7 +486,8 @@ pupilDataService.sqlFindSortedPupilsWithAttendanceReasons = async (dfeNumber, so
   AND ps.code = 'UNALLOC'
   ORDER BY ${sqlSort}
   `
-  return sqlService.query(sql, params)
+  const pupils = await sqlService.query(sql, params)
+  return sqlService.addPupilStatuses(pupils)
 }
 
 pupilDataService.sqlInsertMany = async (pupils) => {

--- a/admin/services/data-access/pupils-not-taking-check.data.service.js
+++ b/admin/services/data-access/pupils-not-taking-check.data.service.js
@@ -26,7 +26,8 @@ const pupilsNotTakingCheckDataService = {
       type: TYPES.Int
     }]
 
-    return sqlService.query(sql, params)
+    const pupils = await sqlService.query(sql, params)
+    return sqlService.addPupilStatuses(pupils)
   },
 
   /**

--- a/admin/services/data-access/sql.service.js
+++ b/admin/services/data-access/sql.service.js
@@ -657,17 +657,17 @@ sqlService.loadTable = async tableName => {
  * @return {Object}
  */
 sqlService.addPupilStatuses = async (results, pupilIDProperty = 'id', replaceWith = { pupilStatus_id: 'id' }) => {
-  let pupils
+  let pupilStatusLink
   try {
-    pupils = await sqlService.loadTable('pupil')
+    pupilStatusLink = await sqlService.loadTable('pupilStatusLink')
   } catch (e) {
     logger.error('sqlService.addPupilStatuses: Reading pupil redis cache failed', e)
     throw e
   }
 
   let pupilStatuses = {}
-  pupils.forEach(p => {
-    pupilStatuses[p.id] = p.pupilStatus_id
+  pupilStatusLink.forEach(p => {
+    pupilStatuses[p.pupil_id] = p.pupilStatus_id
   })
 
   const replaceWithTypes = []
@@ -704,7 +704,7 @@ sqlService.addPupilStatuses = async (results, pupilIDProperty = 'id', replaceWit
   }
 
   results.forEach(r => {
-    const statusID = pupilStatuses[r[pupilIDProperty].toString()]
+    const statusID = pupilStatuses[r[pupilIDProperty].toString()] || 1
     for (let col in replaceWith) {
       let type = replaceWith[col]
       let value = statusID
@@ -745,7 +745,7 @@ const cacheTableInRedis = async (table) => {
  * @return {Object}
  */
 sqlService.startupCacheTables = async () => {
-  const tables = ['pupil', 'pupilStatus', 'pupilStatusCode']
+  const tables = ['pupilStatus', 'pupilStatusCode', 'pupilStatusLink']
   const tablesLn = tables.length
   for (let i = 0; i < tablesLn; i++) {
     await cacheTableInRedis(tables[i])

--- a/admin/services/data-access/sql.service.js
+++ b/admin/services/data-access/sql.service.js
@@ -691,11 +691,16 @@ sqlService.addPupilStatuses = async (results, pupilIDProperty = 'id', replaceWit
  * Cache a SQL Server table in redis
  * Has to be here (instead of redisCacheService) to avoid cyclic dependency
  * @param {string} table - The table to cache in Redis
- * @return {Object}
+ * @return {Array}
  */
 const cacheTableInRedis = async (table) => {
   const result = await sqlService.query(`SELECT * FROM ${sqlService.adminSchema}.[${table}]`)
-  return redisCacheService.set(`table.${table}`, result)
+  try {
+    await redisCacheService.set(`table.${table}`, result)
+    return result
+  } catch (e) {
+    throw e
+  }
 }
 
 /**

--- a/admin/services/data-access/sql.service.js
+++ b/admin/services/data-access/sql.service.js
@@ -641,13 +641,10 @@ sqlService.loadTable = async tableName => {
   if (REDIS_CACHING && REDIS_CACHE_UPDATING) {
     result = redisCacheService.get(`table.${tableName}`)
     if (result) {
-      console.log(`Loaded ${tableName} from REDIS`)
       return result
     }
-    console.log(`Loaded ${tableName} from REDIS`)
     return sqlService.cacheTableInRedis(tableName)
   }
-  console.log(`Loaded ${tableName} from SQL Server`)
   return sqlService.query(`SELECT * FROM ${sqlService.adminSchema}.[${tableName}]`)
 }
 
@@ -753,7 +750,7 @@ sqlService.startupCacheTables = async () => {
   for (let i = 0; i < tablesLn; i++) {
     await cacheTableInRedis(tables[i])
   }
-  console.log(`REDIS (startupCacheTables): cached \`${tables.join('`, `')}\``)
+  logger.info(`REDIS (startupCacheTables): cached \`${tables.join('`, `')}\``)
 }
 
 module.exports = sqlService

--- a/admin/services/pupil.status.service.js
+++ b/admin/services/pupil.status.service.js
@@ -7,6 +7,7 @@ const pupilAttendanceDataService = require('./data-access/pupil-attendance.data.
 const pupilDataService = require('./data-access/pupil.data.service')
 const pupilRestartDataService = require('./data-access/pupil-restart.data.service')
 const pupilStatusCodeDataService = require('./data-access/pupil-status-code.data.service')
+const queueNameService = require('./queue-name-service')
 const R = require('ramda')
 
 const pupilStatusService = {}
@@ -91,8 +92,12 @@ pupilStatusService.dispatchPupilStatusMessages = async (pupils) => {
     throw new Error('Invalid parameter: pupils')
   }
 
+  const pupilStatusQueueName = queueNameService.getName(
+    queueNameService.NAMES.PUPIL_STATUS
+  )
+
   const messages = pupils.map(({ id }) => ({ pupilId: id, checkCode: `pupilId-${id}` }))
-  await azureQueueService.addMessageAsync('pupil-status', { version: 2, messages })
+  await azureQueueService.addMessageAsync(pupilStatusQueueName, { version: 2, messages })
 }
 
 /**

--- a/admin/services/redis-cache.service.js
+++ b/admin/services/redis-cache.service.js
@@ -42,7 +42,7 @@ redisCacheService.get = async redisKey => {
       return false
     }
     logger.info(`REDIS (get): Retrieved \`${redisKey}\``)
-    return result
+    return JSON.parse(result)
   } catch (err) {
     logger.error(`REDIS (get): Error getting \`redisKey\`: ${err.message}`)
     throw err

--- a/functions/config.js
+++ b/functions/config.js
@@ -11,6 +11,7 @@ const getEnvironment = () => {
 module.exports = {
   AZURE_STORAGE_CONNECTION_STRING: process.env.AZURE_STORAGE_CONNECTION_STRING,
   REDIS_CACHING: process.env.hasOwnProperty('REDIS_CACHING') ? toBool(process.env.REDIS_CACHING) : false,
+  REDIS_CACHE_UPDATING: process.env.hasOwnProperty('REDIS_CACHE_UPDATING') ? toBool(process.env.REDIS_CACHE_UPDATING) : false,
   Sql: {
     Database: process.env.SQL_DATABASE || 'mtc',
     Server: process.env.SQL_SERVER || 'localhost',

--- a/functions/pupil-status/pupil-status-batch.service.js
+++ b/functions/pupil-status/pupil-status-batch.service.js
@@ -3,9 +3,7 @@
 const pupilStatusAnalysisService = require('./pupil-status-analysis.service')
 const sqlService = require('../lib/sql/sql.service')
 const { TYPES } = sqlService
-const redisCacheService = require('../../admin/services/redis-cache.service')
-const adminSQLService = require('../../admin/services/data-access/sql.service')
-const { REDIS_CACHING, REDIS_CACHE_UPDATING } = require('../config')
+const pupilStatusRedisService = require('./pupil-status-redis.service')
 
 async function recalculatePupilStatus (context, pupilIds) {
   if (!Array.isArray(pupilIds)) {
@@ -87,66 +85,7 @@ function parseParams (params) {
  * @param {[{pupilId: <number>, targetStatusCode: <string>}]} updates
  */
 const updatePupilStatuses = async (updates, context) => {
-  let pupilStatusLinkTableRedis
-  let pupilStatusTableRedis
-  if (REDIS_CACHING && REDIS_CACHE_UPDATING) {
-    try {
-      pupilStatusLinkTableRedis = await redisCacheService.get('table.pupilStatusLink')
-      pupilStatusTableRedis = await redisCacheService.get('table.pupilStatus')
-      if (!pupilStatusLinkTableRedis) {
-        pupilStatusLinkTableRedis = await adminSQLService.cacheTableInRedis('pupilStatusLink')
-      }
-      if (!pupilStatusTableRedis) {
-        pupilStatusTableRedis = await adminSQLService.cacheTableInRedis('pupilStatus')
-      }
-    } catch (e) {
-      context.log.error('Reading pupil and pupilStatus redis caches in updatePupilStatuses failed')
-      context.log.error(e)
-      throw e
-    }
-  }
-
-  if (pupilStatusLinkTableRedis && pupilStatusTableRedis) {
-    const pupilStatusCodes = {}
-    pupilStatusTableRedis.forEach(e => {
-      pupilStatusCodes[e.code] = e.id
-    })
-
-    const updatesLn = updates.length
-    const pupilTableRedisLn = pupilStatusLinkTableRedis.length
-    for (let i = 0; i < updatesLn; i++) {
-      const update = updates[i]
-      let updated = false
-      for (let j = 0; j < pupilTableRedisLn; j++) {
-        const pupilStatusRow = pupilStatusLinkTableRedis[j]
-        if (update.pupilId === pupilStatusRow.id) {
-          pupilStatusLinkTableRedis[j].pupilStatus_id = pupilStatusCodes[update.targetStatusCode]
-          updated = true
-          break
-        }
-      }
-      if (!updated) {
-        let newID = 1
-        if (pupilStatusLinkTableRedis.length) {
-          newID = Array.from(pupilStatusLinkTableRedis).pop().id + 1
-        }
-        pupilStatusLinkTableRedis.push({
-          id: newID,
-          pupil_id: update.pupilId,
-          pupilStatus_id: pupilStatusCodes[update.targetStatusCode]
-        })
-      }
-    }
-
-    try {
-      await redisCacheService.set('table.pupilStatusLink', pupilStatusLinkTableRedis)
-      context.log('pupil-status: pupil redis cache updated successfully')
-    } catch (e) {
-      context.log.error('pupil-status: setting pupil redis cache in updatePupilStatuses failed')
-      context.log.error(e)
-      throw e
-    }
-  }
+  await pupilStatusRedisService.updatePupilStatuses(updates, context)
 
   const sql = []
   const params = []

--- a/functions/pupil-status/pupil-status-batch.service.js
+++ b/functions/pupil-status/pupil-status-batch.service.js
@@ -43,7 +43,8 @@ async function getCurrentPupilsData (pupilIds) {
     CAST(ISNULL(pupilRestart.check_id, 0) AS BIT) as isRestartWithPinGenerated
   FROM
         [mtc_admin].[pupil] p
-        INNER JOIN [mtc_admin].[pupilStatus] pstatus ON (p.pupilStatus_id = pstatus.id)
+        LEFT JOIN [mtc_admin].[pupilStatusLink] psl ON psl.pupil_id = p.id
+        INNER JOIN [mtc_admin].[pupilStatus] pstatus ON (ISNULL(psl.pupilStatus_id, 1) = pstatus.id)
         LEFT OUTER JOIN
         (
            SELECT *,

--- a/functions/pupil-status/pupil-status-redis.service.js
+++ b/functions/pupil-status/pupil-status-redis.service.js
@@ -1,0 +1,78 @@
+const redisCacheService = require('../../admin/services/redis-cache.service')
+const adminSQLService = require('../../admin/services/data-access/sql.service')
+const { REDIS_CACHING, REDIS_CACHE_UPDATING } = require('../config')
+
+/**
+ * Update a batch of pupils in one redis call
+ * @param {[{pupilId: <number>, targetStatusCode: <string>}]} updates
+ */
+const updatePupilStatuses = async (updates, context) => {
+  if (!REDIS_CACHING || !REDIS_CACHE_UPDATING) {
+    return false
+  }
+
+  let pupilStatusLinkTableRedis
+  let pupilStatusTableRedis
+  try {
+    pupilStatusLinkTableRedis = await redisCacheService.get('table.pupilStatusLink')
+    pupilStatusTableRedis = await redisCacheService.get('table.pupilStatus')
+    if (!pupilStatusLinkTableRedis) {
+      pupilStatusLinkTableRedis = await adminSQLService.cacheTableInRedis('pupilStatusLink')
+    }
+    if (!pupilStatusTableRedis) {
+      pupilStatusTableRedis = await adminSQLService.cacheTableInRedis('pupilStatus')
+    }
+  } catch (e) {
+    context.log.error('Reading pupil and pupilStatus redis caches in updatePupilStatuses failed')
+    context.log.error(e)
+    throw e
+  }
+
+  if (!pupilStatusLinkTableRedis || !pupilStatusTableRedis) {
+    return false
+  }
+
+  const pupilStatusCodes = {}
+  pupilStatusTableRedis.forEach(e => {
+    pupilStatusCodes[e.code] = e.id
+  })
+
+  const updatesLn = updates.length
+  const pupilTableRedisLn = pupilStatusLinkTableRedis.length
+  for (let i = 0; i < updatesLn; i++) {
+    const update = updates[i]
+    let updated = false
+    for (let j = 0; j < pupilTableRedisLn; j++) {
+      const pupilStatusRow = pupilStatusLinkTableRedis[j]
+      if (update.pupilId === pupilStatusRow.id) {
+        pupilStatusLinkTableRedis[j].pupilStatus_id = pupilStatusCodes[update.targetStatusCode]
+        updated = true
+        break
+      }
+    }
+    if (!updated) {
+      let newID = 1
+      if (pupilStatusLinkTableRedis.length) {
+        newID = Array.from(pupilStatusLinkTableRedis).pop().id + 1
+      }
+      pupilStatusLinkTableRedis.push({
+        id: newID,
+        pupil_id: update.pupilId,
+        pupilStatus_id: pupilStatusCodes[update.targetStatusCode]
+      })
+    }
+  }
+
+  try {
+    await redisCacheService.set('table.pupilStatusLink', pupilStatusLinkTableRedis)
+    context.log('pupil-status: pupil redis cache updated successfully')
+  } catch (e) {
+    context.log.error('pupil-status: setting pupil redis cache in updatePupilStatuses failed')
+    context.log.error(e)
+    throw e
+  }
+
+  return true
+}
+
+module.exports = { updatePupilStatuses }

--- a/functions/pupil-status/pupil-status.service.js
+++ b/functions/pupil-status/pupil-status.service.js
@@ -4,7 +4,6 @@ const pupilStatusAnalysisService = require('./pupil-status-analysis.service')
 const R = require('ramda')
 const sqlService = require('../lib/sql/sql.service')
 const { TYPES } = sqlService
-const redisCacheService = require('../../admin/services/redis-cache.service')
 
 async function recalculatePupilStatus (pupilId) {
   const currentData = await getCurrentPupilData(pupilId)
@@ -59,42 +58,15 @@ async function getCurrentPupilData (pupilId) {
   return R.head(res)
 }
 
-async function getPupilStatusID (targetStatusCode) {
-  const rows = await redisCacheService.get('table.pupilStatus')
-  if (!rows) {
-    const sql = `SELECT id FROM [mtc_admin].[pupilStatus] WHERE code = @code`
-    const params = [
-      { name: 'code', value: targetStatusCode, type: TYPES.NVarChar }
-    ]
-    const results = await sqlService.query(sql, params)
-    return results[0].id
-  } else {
-    return rows.find(r => r.code === targetStatusCode).id
-  }
-}
-
 async function changePupilState (pupilId, targetStatusCode) {
-  const statusID = await getPupilStatusID(targetStatusCode)
-  const pupils = await redisCacheService.get('table.pupil')
-  if (pupils) {
-    const pupilsLn = pupils.length
-    for (let i = 0; i < pupilsLn; i++) {
-      if (pupils[i].id === pupilId) {
-        pupils[i].pupilStatus_id = statusID
-        break
-      }
-    }
-    return redisCacheService.set('table.pupil', pupils)
-  } else {
-    const sql = `UPDATE [mtc_admin].[pupil]
-                 SET pupilStatus_id = @statusID
-                 WHERE id = @pupilId`
-    const params = [
-      { name: 'statusID', value: statusID, type: TYPES.Int },
-      { name: 'pupilId', value: pupilId, type: TYPES.Int }
-    ]
-    return sqlService.modify(sql, params)
-  }
+  const sql = `UPDATE [mtc_admin].[pupil]
+               SET pupilStatus_id = (SELECT id from [mtc_admin].[pupilStatus] WHERE code = @code)
+               WHERE id = @pupilId`
+  const params = [
+    { name: 'code', value: targetStatusCode, type: TYPES.NVarChar },
+    { name: 'pupilId', value: pupilId, type: TYPES.Int }
+  ]
+  return sqlService.modify(sql, params)
 }
 
 module.exports = {

--- a/functions/pupil-status/v1.js
+++ b/functions/pupil-status/v1.js
@@ -12,7 +12,7 @@ async function process (context, pupilStatusMessage) {
   }
 
   try {
-    await pupilStatusService.recalculatePupilStatus(pupilStatusMessage.pupilId)
+    await pupilStatusService.recalculatePupilStatus(pupilStatusMessage.pupilId, context)
   } catch (error) {
     context.log.error(`pupil-status: Failed to recalculate pupil status for pupil ${pupilStatusMessage.pupilId}`)
     throw error


### PR DESCRIPTION
A new pupilStatusLink table has been added and all queries/views which were using `pupil.pupilStatus_id` have been updated to use it.

A method has also been added to make it possible to directly update a Redis cache and then put a message into a new Azure message queue for updating the table in SQL Server. A listener has been added to `/functions` to parse these messages.