### PR TITLE
add space to logger output

### DIFF
--- a/admin/models/logger.js
+++ b/admin/models/logger.js
@@ -60,7 +60,7 @@ class Logger {
   }
 
   log (level, msg, exception) {
-    this.logger.log(level, msg, exception)
+    this.logger.log(level, msg + ' ', exception)
   }
 
   /**


### PR DESCRIPTION
Fix for missing space between error UUID and error message.

This has been tested against azure, and will be signed off once travis passes.

![Screenshot 2019-06-21 15 38 53](https://user-images.githubusercontent.com/329532/59930459-d4c1de80-943a-11e9-87e4-66036107131f.png)
