### PR TITLE
Bug/33928 Provided dedicated styling for numpad preview box

### DIFF
--- a/pupil-spa/src/app/aa-fonts/aa-fonts.component.html
+++ b/pupil-spa/src/app/aa-fonts/aa-fonts.component.html
@@ -27,9 +27,9 @@
                   <div class="question-text aa-question-size-{{selectedSize}}">123</div>
                   <table>
                       <tr>
-                          <td><button class="numpad-button-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>1</span></button></td>
-                          <td><button class="numpad-button-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>2</span></button></td>
-                          <td><button class="numpad-button-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>3</span></button></td>
+                          <td><button class="numpad-button-preview-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>1</span></button></td>
+                          <td><button class="numpad-button-preview-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>2</span></button></td>
+                          <td><button class="numpad-button-preview-{{selectedSize}} aa-contrast-invert" type="button" tabindex="-1"><span>3</span></button></td>
                       </tr>
                   </table>
               </div>

--- a/pupil-spa/src/assets/shared-styles/elements/_aa-variables.scss
+++ b/pupil-spa/src/assets/shared-styles/elements/_aa-variables.scss
@@ -82,6 +82,13 @@ $aa-numpad-button-height-regular: 70px;
 $aa-numpad-button-height-small: 50px;
 $aa-numpad-button-height-xsmall: 44px;
 
+$aa-numpad-button-preview-width-xxlarge: 155px;
+$aa-numpad-button-preview-width-xlarge: 125px;
+$aa-numpad-button-preview-width-large: 100px;
+$aa-numpad-button-preview-width-regular: 100px;
+$aa-numpad-button-preview-width-small: 70px;
+$aa-numpad-button-preview-width-xsmall: 60px;
+
 $aa-radio-outside-xxlarge: 38px;
 $aa-radio-outside-xlarge: 30px;
 $aa-radio-outside-large: 24px;

--- a/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
+++ b/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
@@ -68,7 +68,7 @@
     width: $button-preview-width !important;
     height: $button-height !important;
     max-height: $button-height !important;
-    max-width: $button-width !important;
+    max-width: $button-preview-width !important;
   }
 
   .numpad-enter-button-#{$size}, .copy-size-#{$size} .numpad-enter-button {

--- a/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
+++ b/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
@@ -1,6 +1,6 @@
 @import "./aa-variables.scss";
 
-@mixin customsize($size, $button-width, $button-height, $button-number-size, $button-text-size, $answer-width, $answer-height) {
+@mixin customsize($size, $button-width, $button-preview-width, $button-height, $button-number-size, $button-text-size, $answer-width, $answer-height) {
 
   .copy-size-#{$size} .question-container {
     table {
@@ -36,7 +36,7 @@
     }
   }
 
-  .numpad-button-#{$size}, .copy-size-#{$size} .numpad-button,
+  .numpad-button-#{$size}, .numpad-button-preview-#{$size}, .copy-size-#{$size} .numpad-button,
   .numpad-enter-button-#{$size}, .copy-size-#{$size} .numpad-enter-button {
     position: relative;
     font-family: Arial, Segoe UI Symbol, sans-serif !important;
@@ -60,6 +60,17 @@
     max-width: $button-width !important;
   }
 
+  .numpad-button-preview-#{$size}, .copy-size-#{$size} .numpad-button {
+    @include button($grey-1);
+
+    font-size: $button-number-size !important;
+    line-height: $button-height !important;
+    width: $button-preview-width !important;
+    height: $button-height !important;
+    max-height: $button-height !important;
+    max-width: $button-width !important;
+  }
+
   .numpad-enter-button-#{$size}, .copy-size-#{$size} .numpad-enter-button {
     @include button($grey-1);
 
@@ -76,6 +87,7 @@
 @include customsize(
   "xsmall",
   $aa-numpad-button-width-xsmall,
+  $aa-numpad-button-preview-width-xsmall,
   $aa-numpad-button-height-xsmall,
   $aa-numpad-button-number-size-xsmall,
   $aa-numpad-button-text-size-xsmall,
@@ -85,6 +97,7 @@
 @include customsize(
   "small",
   $aa-numpad-button-width-small,
+    $aa-numpad-button-preview-width-small,
   $aa-numpad-button-height-small,
   $aa-numpad-button-number-size-small,
   $aa-numpad-button-text-size-small,
@@ -94,6 +107,7 @@
 @include customsize(
   "regular",
   $aa-numpad-button-width-regular,
+    $aa-numpad-button-preview-width-regular,
   $aa-numpad-button-height-regular,
   $aa-numpad-button-number-size-regular,
   $aa-numpad-button-text-size-regular,
@@ -103,6 +117,7 @@
 @include customsize(
   "large",
   $aa-numpad-button-width-large,
+    $aa-numpad-button-preview-width-large,
   $aa-numpad-button-height-large,
   $aa-numpad-button-number-size-large,
   $aa-numpad-button-text-size-large,
@@ -112,6 +127,7 @@
 @include customsize(
   "xlarge",
   $aa-numpad-button-width-xlarge,
+    $aa-numpad-button-preview-width-xlarge,
   $aa-numpad-button-height-xlarge,
   $aa-numpad-button-number-size-xlarge,
   $aa-numpad-button-text-size-xlarge,
@@ -121,6 +137,7 @@
 @include customsize(
   "xxlarge",
   $aa-numpad-button-width-xxlarge,
+    $aa-numpad-button-preview-width-xxlarge,
   $aa-numpad-button-height-xxlarge,
   $aa-numpad-button-number-size-xxlarge,
   $aa-numpad-button-text-size-xxlarge,

--- a/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
+++ b/pupil-spa/src/assets/shared-styles/elements/_virtual-keyboard.scss
@@ -97,7 +97,7 @@
 @include customsize(
   "small",
   $aa-numpad-button-width-small,
-    $aa-numpad-button-preview-width-small,
+  $aa-numpad-button-preview-width-small,
   $aa-numpad-button-height-small,
   $aa-numpad-button-number-size-small,
   $aa-numpad-button-text-size-small,
@@ -107,7 +107,7 @@
 @include customsize(
   "regular",
   $aa-numpad-button-width-regular,
-    $aa-numpad-button-preview-width-regular,
+  $aa-numpad-button-preview-width-regular,
   $aa-numpad-button-height-regular,
   $aa-numpad-button-number-size-regular,
   $aa-numpad-button-text-size-regular,
@@ -117,7 +117,7 @@
 @include customsize(
   "large",
   $aa-numpad-button-width-large,
-    $aa-numpad-button-preview-width-large,
+  $aa-numpad-button-preview-width-large,
   $aa-numpad-button-height-large,
   $aa-numpad-button-number-size-large,
   $aa-numpad-button-text-size-large,
@@ -127,7 +127,7 @@
 @include customsize(
   "xlarge",
   $aa-numpad-button-width-xlarge,
-    $aa-numpad-button-preview-width-xlarge,
+  $aa-numpad-button-preview-width-xlarge,
   $aa-numpad-button-height-xlarge,
   $aa-numpad-button-number-size-xlarge,
   $aa-numpad-button-text-size-xlarge,
@@ -137,7 +137,7 @@
 @include customsize(
   "xxlarge",
   $aa-numpad-button-width-xxlarge,
-    $aa-numpad-button-preview-width-xxlarge,
+  $aa-numpad-button-preview-width-xxlarge,
   $aa-numpad-button-height-xxlarge,
   $aa-numpad-button-number-size-xxlarge,
   $aa-numpad-button-text-size-xxlarge,

--- a/test/pupil-hpa/features/support/page_objects/font_size_page.rb
+++ b/test/pupil-hpa/features/support/page_objects/font_size_page.rb
@@ -13,37 +13,37 @@ class FontSizePage < SitePrism::Page
   section :very_small_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-xsmall'
-    elements :number_pad, '.numpad-button-xsmall'
+    elements :number_pad, '.numpad-button-preview-xsmall'
   end
 
   section :small_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-small'
-    elements :number_pad, '.numpad-button-small'
+    elements :number_pad, '.numpad-button-preview-small'
   end
 
   section :regular_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-regular'
-    elements :number_pad, '.numpad-button-regular'
+    elements :number_pad, '.numpad-button-preview-regular'
   end
 
   section :large_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-large'
-    elements :number_pad, '.numpad-button-large'
+    elements :number_pad, '.numpad-button-preview-large'
   end
 
   section :very_large_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-xlarge'
-    elements :number_pad, '.numpad-button-xlarge'
+    elements :number_pad, '.numpad-button-preview-xlarge'
   end
 
   section :largest_preview, '.preview-box' do
     element :badge, '.badge', text: 'Size preview'
     element :question, '.question-text.aa-question-size-xxlarge'
-    elements :number_pad, '.numpad-button-xxlarge'
+    elements :number_pad, '.numpad-button-preview-xxlarge'
   end
 
   element :setting_not_needed, '.grid-row p'


### PR DESCRIPTION
Reused styles between preview numpad and actual numpad caused numpad button to exceed the preview box's width

Before:

<img width="855" alt="Screenshot 2019-07-08 at 09 05 38" src="https://user-images.githubusercontent.com/4175503/60793449-a6910e00-a15f-11e9-8530-1cf1068e1074.png">

After:

<img width="942" alt="Screenshot 2019-07-08 at 09 06 00" src="https://user-images.githubusercontent.com/4175503/60793459-abee5880-a15f-11e9-8e61-6e894fee48ec.png">
