### PR TITLE
Feature/36262 add school UUID to check submission

### DIFF
--- a/admin/services/check-start.service.js
+++ b/admin/services/check-start.service.js
@@ -287,6 +287,7 @@ checkStartService.prepareCheckQueueMessages = async function (checkIds, schoolId
 
   const hasLiveChecks = R.all(c => R.equals(c.check_isLiveCheck, true))(checks)
   let checkCompleteSasToken
+  let checkSubmitSasToken
 
   const checkStartedSasToken = sasTokenService.generateSasToken(
     queueNameService.NAMES.CHECK_STARTED,
@@ -299,6 +300,10 @@ checkStartService.prepareCheckQueueMessages = async function (checkIds, schoolId
   if (hasLiveChecks) {
     checkCompleteSasToken = sasTokenService.generateSasToken(
       queueNameService.NAMES.CHECK_COMPLETE,
+      sasExpiryDate
+    )
+    checkSubmitSasToken = sasTokenService.generateSasToken(
+      queueNameService.CHECK_SUBMIT,
       sasExpiryDate
     )
   }
@@ -338,7 +343,8 @@ checkStartService.prepareCheckQueueMessages = async function (checkIds, schoolId
       },
       school: {
         id: o.school_id,
-        name: o.school_name
+        name: o.school_name,
+        uuid: o.school_uuid
       },
       tokens: {
         checkStarted: {
@@ -365,6 +371,10 @@ checkStartService.prepareCheckQueueMessages = async function (checkIds, schoolId
     if (o.check_isLiveCheck) {
       message.tokens.checkComplete = {
         token: checkCompleteSasToken.token,
+        url: checkCompleteSasToken.url
+      }
+      message.tokens.checkSubmit = {
+        token: checkSubmitSasToken.token,
         url: checkCompleteSasToken.url
       }
     }

--- a/admin/services/check-start.service.js
+++ b/admin/services/check-start.service.js
@@ -303,7 +303,7 @@ checkStartService.prepareCheckQueueMessages = async function (checkIds, schoolId
       sasExpiryDate
     )
     checkSubmitSasToken = sasTokenService.generateSasToken(
-      queueNameService.CHECK_SUBMIT,
+      queueNameService.NAMES.CHECK_SUBMIT,
       sasExpiryDate
     )
   }

--- a/admin/services/data-access/check-form-allocation.data.service.js
+++ b/admin/services/data-access/check-form-allocation.data.service.js
@@ -8,7 +8,7 @@ const table = '[checkFormAllocation]'
 const checkFormAllocationDataService = {}
 
 checkFormAllocationDataService.sqlFindByIdsHydrated = function (ids) {
-  const select = `SELECT 
+  const select = `SELECT
       chk.id as check_id,
       chk.checkCode as check_checkCode,
       chk.isLiveCheck as check_isLiveCheck,
@@ -22,10 +22,11 @@ checkFormAllocationDataService.sqlFindByIdsHydrated = function (ids) {
       checkForm.id as checkForm_id,
       checkForm.formData as checkForm_formData,
       school.id as school_id,
+      school.urlSlug as school_uuid,
       school.name as school_name,
       school.pin as school_pin,
       ISNULL(sce.timezone, '${config.DEFAULT_TIMEZONE}') as timezone
-    FROM 
+    FROM
       ${sqlService.adminSchema}.[check] chk
       JOIN ${sqlService.adminSchema}.[pupil] pupil ON (chk.pupil_id = pupil.id)
       JOIN ${sqlService.adminSchema}.[checkForm] checkForm ON (chk.checkForm_id = checkForm.id)

--- a/admin/services/queue-name-service.js
+++ b/admin/services/queue-name-service.js
@@ -2,6 +2,7 @@
 const config = require('../config')
 
 const NAMES = {
+  CHECK_SUBMIT: 'check-submitted', // replaces check-complete
   CHECK_COMPLETE: 'check-complete',
   CHECK_STARTED: 'check-started',
   PREPARE_CHECK: 'prepare-check',

--- a/admin/services/queue-name-service.js
+++ b/admin/services/queue-name-service.js
@@ -2,7 +2,7 @@
 const config = require('../config')
 
 const NAMES = {
-  CHECK_SUBMIT: 'check-submitted', // replaces check-complete
+  CHECK_SUBMIT: 'check-submitted',
   CHECK_COMPLETE: 'check-complete',
   CHECK_STARTED: 'check-started',
   PREPARE_CHECK: 'prepare-check',

--- a/admin/services/queue-name-service.js
+++ b/admin/services/queue-name-service.js
@@ -2,7 +2,7 @@
 const config = require('../config')
 
 const NAMES = {
-  CHECK_SUBMIT: 'check-submitted',
+  CHECK_SUBMIT: 'check-submitted', // replaces check-complete
   CHECK_COMPLETE: 'check-complete',
   CHECK_STARTED: 'check-started',
   PREPARE_CHECK: 'prepare-check',

--- a/admin/spec/back-end/service/check-start.service.spec.js
+++ b/admin/spec/back-end/service/check-start.service.spec.js
@@ -297,6 +297,12 @@ describe('check-start.service', () => {
         expect(Object.keys(res[0].questions[0])).toContain('factor1')
         expect(Object.keys(res[0].questions[0])).toContain('factor2')
       })
+      it('does generate and include check complete & check submit sas tokens when live checks are generated', async () => {
+        const res = await checkStartService.prepareCheckQueueMessages([1], 1)
+        expect(sasTokenService.generateSasToken).toHaveBeenCalledTimes(5)
+        expect(Object.keys(res[0].tokens)).toContain('checkComplete')
+        expect(Object.keys(res[0].tokens)).toContain('checkSubmit')
+      })
     })
     describe('when familiarisation checks are generated', () => {
       beforeEach(() => {

--- a/admin/yarn.lock
+++ b/admin/yarn.lock
@@ -3109,27 +3109,10 @@ gonzales-pe@^4.2.3:
   dependencies:
     minimist "1.1.x"
 
-govuk-elements-sass@^3.1.2:
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/govuk-elements-sass/-/govuk-elements-sass-3.1.3.tgz#ceba688ca7cb7ab64b1427d9e1d44ede4a464712"
-  integrity sha512-uLg/LHSrylkXDKVPlz9uQtdAOQ2CG4rwxPBmQGO5c5QqW4OS83gspNEDaM/dzK2n2OduiieynfkwKbtqR89xiA==
-  dependencies:
-    govuk_frontend_toolkit "^7.1.0"
-
 govuk-frontend@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-3.2.0.tgz#0f935bee092929455bf7ed08bba40ab07ea72769"
   integrity sha512-OtJozAGMEKFu195fNVVrQHUX7+znCkA4cXDKs4lgFlRQOTzN1ogT9010GBARuoTwbeL0VqQ8nerZYjVxH/wafA==
-
-govuk_frontend_toolkit@^7.1.0:
-  version "7.6.0"
-  resolved "https://registry.yarnpkg.com/govuk_frontend_toolkit/-/govuk_frontend_toolkit-7.6.0.tgz#b09a60631afbba4bfac76a8b7c02e72419c29cf5"
-  integrity sha1-sJpgYxr7ukv6x2qLfALnJBnCnPU=
-
-govuk_template_ejs@^0.23.0:
-  version "0.23.3"
-  resolved "https://registry.yarnpkg.com/govuk_template_ejs/-/govuk_template_ejs-0.23.3.tgz#e1e724e8e07eb33f73521843349c53612a9fed21"
-  integrity sha1-4eck6OB+sz9zUhhDNJxTYSqf7SE=
 
 graceful-fs@^3.0.0:
   version "3.0.11"

--- a/pupil-api/readme.md
+++ b/pupil-api/readme.md
@@ -42,7 +42,7 @@ if you have created one.  See [documentation](https://www.npmjs.com/package/dote
 * PORT - number - defaults to `3003`
 * LOG_LEVEL - string - defaults to `debug`
 * EXPRESS_LOGGING_WINSTON - bool - defaults to `false`
-* CORS_WHITELIST - string - defaults to `http://localhost:4200` Can be a comma separated list
+* CORS_WHITELIST - string - Can be a comma separated list
 * APPINSIGHTS_WINSTON_LOGGER - bool - defaults to `false`
 * APPINSIGHTS_INSTRUMENTATIONKEY - string
 

--- a/pupil-spa/gen_config.sh
+++ b/pupil-spa/gen_config.sh
@@ -21,6 +21,8 @@ connectivityCheckEnabled=${CONNECTIVITY_CHECK_ENABLED:-"false"}
 supportNumber=${SUPPORT_NUMBER:-"0300 303 3013"}
 gaCode=${GA_CODE:-"null"}
 websiteOffline=${WEBSITE_OFFLINE:-"false"}
+submitsToCheckReceiver=${SUBMITS_TO_CHECK_RECEIVER:-"false"}
+
 if [ $gaCode == "null" ]
 then
     gaCodeParsed="null"
@@ -57,6 +59,7 @@ cat <<EOF > config.json
   "googleAnalyticsTrackingCode": $gaCodeParsed,
   "applicationInsightsInstrumentationKey": $applicationInsightsCodeParsed,
   "websiteOffline": $websiteOffline,
-  "connectivityCheckEnabled": $connectivityCheckEnabled
+  "connectivityCheckEnabled": $connectivityCheckEnabled,
+  "submitsToCheckReceiver": $submitsToCheckReceiver
 }
 EOF

--- a/pupil-spa/src/app/services/check-complete/check-complete.service.spec.ts
+++ b/pupil-spa/src/app/services/check-complete/check-complete.service.spec.ts
@@ -65,9 +65,16 @@ describe('CheckCompleteService', () => {
     spyOn(appUsageService , 'store');
     spyOn(tokenService, 'getToken').and.returnValue({url: 'url', token: 'token'});
     spyOn(storageService, 'setItem');
-    spyOn(storageService, 'getAllItems').and.returnValue({pupil: {checkCode: 'checkCode'}});
-    spyOn(azureQueueService, 'addMessage')
-      .and.returnValue(Promise.resolve());
+    spyOn(storageService, 'getAllItems').and.returnValue({
+      pupil: {
+        checkCode: 'checkCode'
+      },
+      school: {
+        uuid: 'school_uuid'
+      }
+    });
+
+    spyOn(azureQueueService, 'addMessage').and.returnValue(Promise.resolve());
     await checkCompleteService.submit(Date.now());
     expect(addEntrySpy).toHaveBeenCalledTimes(2);
     expect(appUsageService.store).toHaveBeenCalledTimes(1);

--- a/pupil-spa/src/app/services/check-complete/check-complete.service.spec.ts
+++ b/pupil-spa/src/app/services/check-complete/check-complete.service.spec.ts
@@ -4,7 +4,7 @@ import { Router } from '@angular/router';
 import { AuditService } from '../audit/audit.service';
 import { AzureQueueService } from '../azure-queue/azure-queue.service';
 import { CheckCompleteService } from './check-complete.service';
-import { AppConfigService, loadConfigMockService } from '../config/config.service';
+import { AppConfigService, loadConfigMockService, IAppConfig } from '../config/config.service';
 import { StorageService } from '../storage/storage.service';
 import { TestBed } from '@angular/core/testing';
 import { TokenService } from '../token/token.service';
@@ -56,9 +56,11 @@ describe('CheckCompleteService', () => {
     checkCompleteService.checkSubmissionApiErrorDelay = 100;
     checkCompleteService.checkSubmissionAPIErrorMaxAttempts = 1;
   });
+
   it('should be created', () => {
     expect(checkCompleteService).toBeTruthy();
   });
+
   it('submit should call azure queue service successfully, audit successful call and redirect to check complete page', async () => {
     const addEntrySpy = spyOn(auditService, 'addEntry');
     spyOn(storageService, 'getItem').and.callFake(arg => getItemMock(arg, false));
@@ -74,7 +76,6 @@ describe('CheckCompleteService', () => {
         uuid: expectedSchoolUUID
       }
     });
-    // spyOn(azureQueueService, 'addMessage').and.returnValue(Promise.resolve());
     let capturedMessage;
     spyOn(azureQueueService, 'addMessage').and.callFake((queueName, url, token, message, retryConfig) => {
       capturedMessage = message;
@@ -91,6 +92,25 @@ describe('CheckCompleteService', () => {
     expect(storageService.getAllItems).toHaveBeenCalledTimes(1);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/check-complete']);
   });
+
+  it('uses checkComplete token by default', async () => {
+    spyOn(storageService, 'getItem').and.callFake(arg => getItemMock(arg, false));
+    spyOn(appUsageService , 'store');
+    spyOn(tokenService, 'getToken').and.returnValue({url: 'url', token: 'token'});
+    spyOn(storageService, 'setItem');
+    const expectedSchoolUUID = 'school_uuid';
+    spyOn(storageService, 'getAllItems').and.returnValue({
+      pupil: {
+        checkCode: 'checkCode'
+      },
+      school: {
+        uuid: expectedSchoolUUID
+      }
+    });
+    await checkCompleteService.submit(Date.now());
+    expect(tokenService.getToken).toHaveBeenCalledWith('checkComplete');
+  });
+
   it(`submit should call azure queue service service unsuccessfully, audit failure
     and redirect to submission failed page`, async () => {
     const addEntrySpy = spyOn(auditService, 'addEntry');
@@ -111,6 +131,7 @@ describe('CheckCompleteService', () => {
     expect(storageService.getAllItems).toHaveBeenCalledTimes(1);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/submission-failed']);
   });
+
   it(`submit should call azure queue service service when sas token has expired and redirect to session expiry page`, async () => {
     const addEntrySpy = spyOn(auditService, 'addEntry');
     spyOn(storageService, 'getItem').and.callFake(arg => getItemMock(arg, false));
@@ -133,6 +154,7 @@ describe('CheckCompleteService', () => {
     expect(storageService.getAllItems).toHaveBeenCalledTimes(1);
     expect(mockRouter.navigate).toHaveBeenCalledWith(['/session-expired']);
   });
+
   it('submit should return if the app is configured to run in practice mode', async () => {
     const addEntrySpy = spyOn(auditService, 'addEntry');
     spyOn(storageService, 'getItem').and.callFake(arg => getItemMock(arg, true));

--- a/pupil-spa/src/app/services/check-complete/check-complete.service.ts
+++ b/pupil-spa/src/app/services/check-complete/check-complete.service.ts
@@ -72,11 +72,13 @@ export class CheckCompleteService {
     const excludedItems = ['access_token', 'checkstate', 'pending_submission', 'completed_submission'];
     excludedItems.forEach(i => delete payload[i]);
     payload.checkCode = payload && payload.pupil && payload.pupil.checkCode;
+    payload.schoolUUID = payload && payload.school && payload.school.uuid
     const checkConfig = this.storageService.getItem(CheckCompleteService.configStorageKey);
     if (checkConfig.compressCompletedCheck) {
       message = {
         version: 2,
         checkCode: payload.checkCode,
+        schoolUUID: payload.schoolUUID,
         archive: CompressorService.compress(JSON.stringify(payload))
       };
     } else {

--- a/pupil-spa/src/app/services/config/config.service.ts
+++ b/pupil-spa/src/app/services/config/config.service.ts
@@ -1,4 +1,4 @@
-import { Inject, Injectable } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import 'rxjs/add/operator/catch';
@@ -23,6 +23,7 @@ export interface IAppConfig {
   pupilPrefsAPIErrorDelay: number;
   pupilPrefsAPIErrorMaxAttempts: number;
   connectivityCheckEnabled: boolean;
+  submitsToCheckReceiver: boolean;
 }
 
 export class AppConfig implements IAppConfig {
@@ -49,6 +50,7 @@ export class AppConfig implements IAppConfig {
   readonly testPupilConnectionDelay: number;
   readonly testPupilConnectionMaxAttempts: number;
   readonly connectivityCheckEnabled: boolean;
+  readonly submitsToCheckReceiver: boolean;
 }
 
 /**


### PR DESCRIPTION
- [ ] initialise prepared check with school UUID
- [x] include new 'check-submitted' token in payload
- [x] submit message with `schoolUUID` as top level property
- [x] add configuration to SPA to allow future submission to check-submitted queue