### PR TITLE
Bug/38070 tio checks expiring

### DIFF
--- a/pupil-api/src/services/redis-pupil-auth.service.spec.ts
+++ b/pupil-api/src/services/redis-pupil-auth.service.spec.ts
@@ -26,9 +26,8 @@ describe('redis-pupil-auth.service', () => {
 
   test('it should call redis:get with correct key format', async () => {
     let actualKey: string
-    redisServiceMock.get = jest.fn((key: string) => {
+    redisServiceMock.get = jest.fn(async (key: string) => {
       actualKey = key
-      return Promise.resolve()
     })
     const schoolPin = 'abc12def'
     const pupilPin = '5678'
@@ -60,10 +59,12 @@ describe('redis-pupil-auth.service', () => {
 
   test('the check payload should be returned if item found in cache', async () => {
     const expectedPayload = {
-      foo: 'bar'
+      config: {
+        practice: true
+      }
     }
-    redisServiceMock.get = jest.fn((key: string) => {
-      return Promise.resolve(expectedPayload)
+    redisServiceMock.get = jest.fn(async (key: string) => {
+      return expectedPayload
     })
     const schoolPin = 'abc12def'
     const pupilPin = '5678'
@@ -73,10 +74,13 @@ describe('redis-pupil-auth.service', () => {
 
   test('a lookup link should be added to redis for check-started function', async () => {
     const expectedPayload = {
-      checkCode: 'the-check-code'
+      checkCode: 'the-check-code',
+      config: {
+        practice: true
+      }
     }
-    redisServiceMock.get = jest.fn((key: string) => {
-      return Promise.resolve(expectedPayload)
+    redisServiceMock.get = jest.fn(async (key: string) => {
+      return expectedPayload
     })
     const eightHoursInSeconds = 28800
     const schoolPin = 'abc12def'
@@ -97,30 +101,55 @@ describe('redis-pupil-auth.service', () => {
     expect(payload).toBeNull()
   })
 
-  test('redis item TTL should be set to 30 minutes from now', async () => {
+  test('redis item TTL should be set to 30 minutes from now if a live check', async () => {
     const thirtyMinutesInSeconds = 1800
     const eightHoursInSeconds = 28800
     const expectedPayload = {
-      foo: 'bar'
+      config: {
+        practice: false
+      }
     }
 
-    redisServiceMock.get = jest.fn((key: string) => {
-      return Promise.resolve(JSON.stringify(expectedPayload))
+    redisServiceMock.get = jest.fn(async (key: string) => {
+      return expectedPayload
     })
     let actualLookupKeyExpiryValue: number
-    redisServiceMock.setex = jest.fn((key: string, value: string | object, ttl: number) => {
+    redisServiceMock.setex = jest.fn(async (key: string, value: string | object, ttl: number) => {
       actualLookupKeyExpiryValue = ttl
-      return Promise.resolve()
     })
     let actualPreparedCheckExpiryValue: number
-    redisServiceMock.expire = jest.fn((key: string, ttl: number) => {
+    redisServiceMock.expire = jest.fn(async (key: string, ttl: number) => {
       actualPreparedCheckExpiryValue = ttl
-      return Promise.resolve()
     })
     const schoolPin = 'abc12def'
     const pupilPin = '5678'
     await sut.authenticate(schoolPin, pupilPin)
     expect(actualLookupKeyExpiryValue).toEqual(eightHoursInSeconds)
     expect(actualPreparedCheckExpiryValue).toEqual(thirtyMinutesInSeconds)
+  })
+
+  test('no redis expiry is set if a practice check', async () => {
+
+    const expectedPayload = {
+      config: {
+        practice: true
+      }
+    }
+
+    redisServiceMock.get = jest.fn(async (key: string) => {
+      return expectedPayload
+    })
+    let actualLookupKeyExpiryValue: number
+    redisServiceMock.setex = jest.fn(async (key: string, value: string | object, ttl: number) => {
+      actualLookupKeyExpiryValue = ttl
+    })
+    let actualPreparedCheckExpiryValue: number
+    redisServiceMock.expire = jest.fn(async (key: string, ttl: number) => {
+      actualPreparedCheckExpiryValue = ttl
+    })
+    const schoolPin = 'abc12def'
+    const pupilPin = '5678'
+    await sut.authenticate(schoolPin, pupilPin)
+    expect(redisServiceMock.expire).not.toHaveBeenCalled()
   })
 })

--- a/pupil-api/src/services/redis-pupil-auth.service.ts
+++ b/pupil-api/src/services/redis-pupil-auth.service.ts
@@ -37,7 +37,9 @@ export class RedisPupilAuthenticationService implements IPupilAuthenticationServ
     azureQueueService.addMessage('pupil-login', pupilLoginMessage)
     const checkStartedLookupKey = this.buildCheckStartedLookupKey(preparedCheckEntry.checkCode)
     await this.redisService.setex(checkStartedLookupKey, cacheKey, this.eightHoursInSeconds)
-    await this.redisService.expire(cacheKey, config.RedisPreparedCheckExpiryInSeconds)
+    if (preparedCheckEntry.config.practice === false) {
+      await this.redisService.expire(cacheKey, config.RedisPreparedCheckExpiryInSeconds)
+    }
     return preparedCheckEntry
   }
 

--- a/tslib/src/functions/check-started/check-started.service.spec.ts
+++ b/tslib/src/functions/check-started/check-started.service.spec.ts
@@ -20,23 +20,6 @@ describe('check-started.service', () => {
     expect(sut).toBeDefined()
   })
 
-  test('it looks up preparedCheck redis key via check started link key to delete preparedCheck', async () => {
-    const message: ICheckStartedMessage = {
-      checkCode: 'check-code',
-      clientCheckStartedAt: new Date(),
-      version: 1
-    }
-    const cacheLookupKey = `check-started-check-lookup:${message.checkCode}`
-    const preparedCheckKey = 'prepared-check-key'
-
-    redisServiceMock.get = jest.fn(async (key: string) => {
-      return preparedCheckKey
-    })
-    await sut.process(message, functionBindings)
-    expect(redisServiceMock.get).toHaveBeenCalledWith(cacheLookupKey)
-    expect(redisServiceMock.drop).toHaveBeenCalledWith([preparedCheckKey])
-  })
-
   test('it appends the check-started entry to azure table storage output binding', async () => {
     const message: ICheckStartedMessage = {
       checkCode: 'check-code',
@@ -46,9 +29,65 @@ describe('check-started.service', () => {
     const preparedCheckKey = 'prepared-check-key'
 
     redisServiceMock.get = jest.fn(async (key: string) => {
-      return preparedCheckKey
+      if (key.startsWith('check-started-check-lookup')) {
+        return preparedCheckKey
+      } else {
+        return {
+          config: {
+            practice: false
+          }
+        }
+      }
     })
     await sut.process(message, functionBindings)
     expect(functionBindings.checkStartedTable.length).toBe(1)
+  })
+
+  test('it drops preparedCheck from redis if a live check', async () => {
+    const message: ICheckStartedMessage = {
+      checkCode: 'check-code',
+      clientCheckStartedAt: new Date(),
+      version: 1
+    }
+    const preparedCheckKey = 'prepared-check-key'
+
+    redisServiceMock.get = jest.fn(async (key: string) => {
+      if (key.startsWith('check-started-check-lookup')) {
+        return preparedCheckKey
+      } else {
+        return {
+          config: {
+            practice: false
+          }
+        }
+      }
+    })
+    await sut.process(message, functionBindings)
+    expect(redisServiceMock.drop).toHaveBeenCalledTimes(1)
+    expect(redisServiceMock.drop).toHaveBeenCalledWith([preparedCheckKey])
+  })
+
+  test('it does not drop preparedCheck from redis if a practice check', async () => {
+    const message: ICheckStartedMessage = {
+      checkCode: 'check-code',
+      clientCheckStartedAt: new Date(),
+      version: 1
+    }
+    const preparedCheckKey = 'prepared-check-key'
+
+    redisServiceMock.get = jest.fn(async (key: string) => {
+
+      if (key.startsWith('check-started-check-lookup')) {
+        return preparedCheckKey
+      } else {
+        return {
+          config: {
+            practice: true
+          }
+        }
+      }
+    })
+    await sut.process(message, functionBindings)
+    expect(redisServiceMock.drop).not.toHaveBeenCalled()
   })
 })

--- a/tslib/src/functions/check-started/check-started.service.ts
+++ b/tslib/src/functions/check-started/check-started.service.ts
@@ -17,7 +17,6 @@ export class CheckStartedService {
   }
 
   async process (checkStartedMessage: ICheckStartedMessage, functionBindings: ICheckStartedFunctionBindings): Promise<void> {
-    console.dir(functionBindings)
     const cacheLookupKey = this.buildCacheKey(checkStartedMessage.checkCode)
     const preparedCheckKey = await this.redisService.get(cacheLookupKey)
     functionBindings.checkStartedTable = []
@@ -26,7 +25,10 @@ export class CheckStartedService {
       RowKey: v4(),
       clientCheckStartedAt: checkStartedMessage.clientCheckStartedAt
     })
-    return this.redisService.drop([preparedCheckKey])
+    const preparedCheck = await this.redisService.get(preparedCheckKey)
+    if (preparedCheck.config.practice === false) {
+      return this.redisService.drop([preparedCheckKey])
+    }
   }
 
   private buildCacheKey (checkCode: string): string {


### PR DESCRIPTION
- [x] fix check-started function to only drop preparedCheck if `practice: false`
- [x] fix pupil-api to only set expiry if `practice: false`