### PR TITLE
Feature/38148 check look up redis key

### DIFF
--- a/admin/services/prepare-check.service.js
+++ b/admin/services/prepare-check.service.js
@@ -35,7 +35,7 @@ const service = {
 }
 
 function buildLookupKey (checkCode) {
-  return `check-started-check-lookup:${checkCode}`
+  return `prepared-check-lookup:${checkCode}`
 }
 
 /**

--- a/admin/spec/back-end/service/prepare-check.service.spec.js
+++ b/admin/spec/back-end/service/prepare-check.service.spec.js
@@ -58,7 +58,6 @@ describe('prepare-check.service', () => {
     const expectedLookupKey = `check-started-check-lookup:${check.checkCode}`
     const expectedPreparedCheckKey = `preparedCheck:${check.schoolPin}:${check.pupilPin}`
     spyOn(redisService, 'setMany').and.callFake((batch, ttl) => {
-      console.dir(batch)
       actualPreparedCheckKey = batch[0].key
       actualLookupKey = batch[1].key
     })

--- a/admin/spec/back-end/service/prepare-check.service.spec.js
+++ b/admin/spec/back-end/service/prepare-check.service.spec.js
@@ -10,6 +10,7 @@ let check
 describe('prepare-check.service', () => {
   beforeEach(() => {
     check = {
+      checkCode: 'check-code',
       schoolPin: 'school-pin',
       pupilPin: 'pupil-pin',
       pupil: {
@@ -50,15 +51,20 @@ describe('prepare-check.service', () => {
     }
   })
 
-  it('should add each check with the expected cache key', async () => {
-    let actualKey
+  it('should add each check with the expected cache key and a lookup item', async () => {
+    let actualPreparedCheckKey, actualLookupKey
     check.schoolPin = 'schoolPin'
     check.pupilPin = 'pupilPin'
+    const expectedLookupKey = `check-started-check-lookup:${check.checkCode}`
+    const expectedPreparedCheckKey = `preparedCheck:${check.schoolPin}:${check.pupilPin}`
     spyOn(redisService, 'setMany').and.callFake((batch, ttl) => {
-      actualKey = batch[0].key
+      console.dir(batch)
+      actualPreparedCheckKey = batch[0].key
+      actualLookupKey = batch[1].key
     })
     await sut.prepareChecks([check])
-    expect(actualKey).toEqual(`preparedCheck:${check.schoolPin}:${check.pupilPin}`)
+    expect(actualPreparedCheckKey).toEqual(expectedPreparedCheckKey)
+    expect(actualLookupKey).toEqual(expectedLookupKey)
   })
 
   it('should cache each item with the expected structure', async () => {
@@ -80,14 +86,16 @@ describe('prepare-check.service', () => {
   })
 
   it('should cache each item with the expected ttl', async () => {
-    let ttl
+    let actualPreparedCheckTtl, actualLookupKeyTtl
     const fullTestRunToleranceInSeconds = 60
     const fiveHoursInSeconds = 18000
     spyOn(redisService, 'setMany').and.callFake((items) => {
-      ttl = items[0].ttl
+      actualPreparedCheckTtl = items[0].ttl
+      actualLookupKeyTtl = items[1].ttl
     })
     await sut.prepareChecks([check])
-    expect(ttl).toBeGreaterThan(fiveHoursInSeconds - fullTestRunToleranceInSeconds)
-    expect(ttl).toBeLessThanOrEqual(fiveHoursInSeconds)
+    expect(actualPreparedCheckTtl).toBeGreaterThan(fiveHoursInSeconds - fullTestRunToleranceInSeconds)
+    expect(actualPreparedCheckTtl).toBeLessThanOrEqual(fiveHoursInSeconds)
+    expect(actualLookupKeyTtl).toEqual(actualPreparedCheckTtl)
   })
 })

--- a/admin/spec/back-end/service/prepare-check.service.spec.js
+++ b/admin/spec/back-end/service/prepare-check.service.spec.js
@@ -55,7 +55,7 @@ describe('prepare-check.service', () => {
     let actualPreparedCheckKey, actualLookupKey
     check.schoolPin = 'schoolPin'
     check.pupilPin = 'pupilPin'
-    const expectedLookupKey = `check-started-check-lookup:${check.checkCode}`
+    const expectedLookupKey = `prepared-check-lookup:${check.checkCode}`
     const expectedPreparedCheckKey = `preparedCheck:${check.schoolPin}:${check.pupilPin}`
     spyOn(redisService, 'setMany').and.callFake((batch, ttl) => {
       actualPreparedCheckKey = batch[0].key

--- a/func-consumption/readme.md
+++ b/func-consumption/readme.md
@@ -14,3 +14,21 @@ running `yarn start` does the following...
 - `tslib` is transpiled and output to `func-consumption/dist`
 - 'non production' outputs are removed (such as spec files)
 - the function runtime host is started, and the functions are operational
+
+## configuration
+
+a local.settings.json file is required in the root of the project, with a minimum of these values...
+
+```
+{
+  "IsEncrypted": false,
+  "Values": {
+    "FUNCTIONS_WORKER_RUNTIME": "node",
+    "AzureWebJobsStorage": "{AzureWebJobsStorage}",
+    "AZURE_STORAGE_CONNECTION_STRING": "{your storage account connection}",
+    "ServiceBusConnection": "{your service bus connection}",
+    "CORS_WHITELIST": "http://localhost:4200"
+  },
+  "ConnectionStrings": {}
+}
+```

--- a/pupil-api/src/services/redis-pupil-auth.service.spec.ts
+++ b/pupil-api/src/services/redis-pupil-auth.service.spec.ts
@@ -73,25 +73,6 @@ describe('redis-pupil-auth.service', () => {
     expect(payload).toEqual(expectedPayload)
   })
 
-  test('a lookup link should be added to redis for check-started function', async () => {
-    const expectedPayload = {
-      checkCode: 'the-check-code',
-      config: {
-        practice: true
-      }
-    }
-    redisServiceMock.get = jest.fn(async (key: string) => {
-      return expectedPayload
-    })
-    const eightHoursInSeconds = 28800
-    const schoolPin = 'abc12def'
-    const pupilPin = '5678'
-    await sut.authenticate(schoolPin, pupilPin)
-    const preparedCheckKey = `preparedCheck:${schoolPin}:${pupilPin}`
-    const checkStartedKey = `check-started-check-lookup:${expectedPayload.checkCode}`
-    expect(redisServiceMock.setex).toHaveBeenCalledWith(checkStartedKey, preparedCheckKey, eightHoursInSeconds)
-  })
-
   test('null should be returned if item not found in cache', async () => {
     redisServiceMock.get = jest.fn((key: string) => {
       return Promise.resolve(undefined)
@@ -104,7 +85,6 @@ describe('redis-pupil-auth.service', () => {
 
   test('redis item TTL should be set to 30 minutes from now if config.practice is defined and false', async () => {
     const thirtyMinutesInSeconds = 1800
-    const eightHoursInSeconds = 28800
     const expectedPayload = {
       config: {
         practice: false
@@ -114,10 +94,7 @@ describe('redis-pupil-auth.service', () => {
     redisServiceMock.get = jest.fn(async (key: string) => {
       return expectedPayload
     })
-    let actualLookupKeyExpiryValue: number
-    redisServiceMock.setex = jest.fn(async (key: string, value: string | object, ttl: number) => {
-      actualLookupKeyExpiryValue = ttl
-    })
+
     let actualPreparedCheckExpiryValue: number
     redisServiceMock.expire = jest.fn(async (key: string, ttl: number) => {
       actualPreparedCheckExpiryValue = ttl
@@ -125,7 +102,6 @@ describe('redis-pupil-auth.service', () => {
     const schoolPin = 'abc12def'
     const pupilPin = '5678'
     await sut.authenticate(schoolPin, pupilPin)
-    expect(actualLookupKeyExpiryValue).toEqual(eightHoursInSeconds)
     expect(actualPreparedCheckExpiryValue).toEqual(thirtyMinutesInSeconds)
   })
 

--- a/pupil-api/src/services/redis-pupil-auth.service.ts
+++ b/pupil-api/src/services/redis-pupil-auth.service.ts
@@ -9,7 +9,6 @@ export interface IPupilAuthenticationService {
 export class RedisPupilAuthenticationService implements IPupilAuthenticationService {
 
   private redisService: IRedisService
-  private eightHoursInSeconds: number = 28800
 
   constructor (redisService?: IRedisService) {
     if (redisService === undefined) {
@@ -35,16 +34,10 @@ export class RedisPupilAuthenticationService implements IPupilAuthenticationServ
       version: 1
     }
     azureQueueService.addMessage('pupil-login', pupilLoginMessage)
-    const checkStartedLookupKey = this.buildCheckStartedLookupKey(preparedCheckEntry.checkCode)
-    await this.redisService.setex(checkStartedLookupKey, cacheKey, this.eightHoursInSeconds)
     if (preparedCheckEntry.config.practice === false) {
       await this.redisService.expire(cacheKey, config.RedisPreparedCheckExpiryInSeconds)
     }
     return preparedCheckEntry
-  }
-
-  private buildCheckStartedLookupKey (checkCode: string) {
-    return `check-started-check-lookup:${checkCode}`
   }
 
   private buildCacheKey (schoolPin: string, pupilPin: string): string {

--- a/test/pupil-hpa/features/pupil_api.feature
+++ b/test/pupil-hpa/features/pupil_api.feature
@@ -18,4 +18,9 @@ Feature: Pupil Api
     When I make a request to login
     Then I should see the expiry time change to 30 minutes
 
+  @new_check_process
+  Scenario: Prepared check data can be looked up via check code
+    Given I have generated a pin for a pupil
+    Then I should be able to lookup the prepared check using the check code
+
 

--- a/test/pupil-hpa/features/step_definitions/pupil_api.rb
+++ b/test/pupil-hpa/features/step_definitions/pupil_api.rb
@@ -82,3 +82,10 @@ Then(/^I should see the expiry time change to (\d+) minutes$/) do |value|
   expect(@after_login/60).to be <= value.to_i
   expect(@after_login/60).to be > value.to_i - 3
 end
+
+
+Then(/^I should be able to lookup the prepared check using the check code$/) do
+  pupil_id = SqlDbHelper.find_pupil_via_pin(@pupil_credentials[:pin])['id']
+  check_code = SqlDbHelper.check_details(pupil_id)['checkCode']
+  expect(REDIS_CLIENT.get(JSON.parse(REDIS_CLIENT.get("prepared-check-lookup:#{check_code}"))['value'])).to_not be_nil
+end

--- a/test/pupil-hpa/features/support/sql_db_helper.rb
+++ b/test/pupil-hpa/features/support/sql_db_helper.rb
@@ -169,6 +169,14 @@ class SqlDbHelper
     data
   end
 
+  def self.check_details(pupil_id)
+    sql = "SELECT * FROM [mtc_admin].[check] WHERE pupil_id = '#{pupil_id}' ORDER BY id DESC"
+    result = SQL_CLIENT.execute(sql)
+    chk_res = result.first
+    result.cancel
+    chk_res
+  end
+
   def self.get_pupil_check_form_allocation(pupil_id)
     sql = "SELECT * FROM [mtc_admin].[checkFormAllocation] WHERE pupil_Id='#{pupil_id}'"
     result = SQL_CLIENT.execute(sql)

--- a/tslib/src/functions/check-started/check-started.service.spec.ts
+++ b/tslib/src/functions/check-started/check-started.service.spec.ts
@@ -29,7 +29,7 @@ describe('check-started.service', () => {
     const preparedCheckKey = 'prepared-check-key'
 
     redisServiceMock.get = jest.fn(async (key: string) => {
-      if (key.startsWith('check-started-check-lookup')) {
+      if (key.startsWith('prepared-check-lookup')) {
         return preparedCheckKey
       } else {
         return {
@@ -52,7 +52,7 @@ describe('check-started.service', () => {
     const preparedCheckKey = 'prepared-check-key'
 
     redisServiceMock.get = jest.fn(async (key: string) => {
-      if (key.startsWith('check-started-check-lookup')) {
+      if (key.startsWith('prepared-check-lookup')) {
         return preparedCheckKey
       } else {
         return {
@@ -77,7 +77,7 @@ describe('check-started.service', () => {
 
     redisServiceMock.get = jest.fn(async (key: string) => {
 
-      if (key.startsWith('check-started-check-lookup')) {
+      if (key.startsWith('prepared-check-lookup')) {
         return preparedCheckKey
       } else {
         return {

--- a/tslib/src/functions/check-started/check-started.service.ts
+++ b/tslib/src/functions/check-started/check-started.service.ts
@@ -32,7 +32,7 @@ export class CheckStartedService {
   }
 
   private buildCacheKey (checkCode: string): string {
-    return `check-started-check-lookup:${checkCode}`
+    return `prepared-check-lookup:${checkCode}`
   }
 }
 export interface ICheckStartedMessage {

--- a/tslib/src/functions/pupil-auth/pupil-auth.service.spec.ts
+++ b/tslib/src/functions/pupil-auth/pupil-auth.service.spec.ts
@@ -97,22 +97,6 @@ describe('pupil-auth.service', () => {
     expect(res.body).toEqual(preparedCheck)
   })
 
-  test('when prepared check found, lookup key is added to redis', async () => {
-    const preparedCheck = {
-      checkCode: 'abc',
-      config: {
-        practice: false
-      }
-    }
-    redisMock.get = jest.fn(async (key) => {
-      return preparedCheck
-    })
-    const preparedCheckKey = `preparedCheck:${req.body.schoolPin}:${req.body.pupilPin}`
-    const lookupKey = `check-started-check-lookup:${preparedCheck.checkCode}`
-    await sut.authenticate(bindings, req)
-    expect(redisMock.setex).toHaveBeenCalledWith(lookupKey, preparedCheckKey, 28800)
-  })
-
   test('expire if live check', async () => {
     const preparedCheck = {
       checkCode: 'abc',

--- a/tslib/src/functions/pupil-auth/pupil-auth.service.ts
+++ b/tslib/src/functions/pupil-auth/pupil-auth.service.ts
@@ -18,7 +18,6 @@ export interface IHttpResponse {
 export class PupilAuthService {
 
   private redisService: IRedisService
-  private eightHoursInSeconds: number = 28800
 
   constructor (redisService?: IRedisService) {
     if (redisService === undefined) {
@@ -53,9 +52,6 @@ export class PupilAuthService {
     const preparedCheck = await this.redisService.get(cacheKey)
     if (!preparedCheck) return noAuth
 
-    const checkStartedLookupKey = this.buildCheckStartedLookupKey(preparedCheck.checkCode)
-    await this.redisService.setex(checkStartedLookupKey, cacheKey, this.eightHoursInSeconds)
-
     if (preparedCheck.config.practice === false) {
       await this.redisService.expire(cacheKey, config.PupilAuth.PreparedCheckExpiryAfterLoginSeconds)
     }
@@ -78,10 +74,6 @@ export class PupilAuthService {
         'Access-Control-Allow-Origin': config.PupilAuth.CorsWhitelist
       }
     }
-  }
-
-  private buildCheckStartedLookupKey (checkCode: string) {
-    return `check-started-check-lookup:${checkCode}`
   }
 
   private buildCacheKey (schoolPin: string, pupilPin: string): string {

--- a/tslib/src/functions/pupil-auth/pupil-auth.service.ts
+++ b/tslib/src/functions/pupil-auth/pupil-auth.service.ts
@@ -79,5 +79,4 @@ export class PupilAuthService {
   private buildCacheKey (schoolPin: string, pupilPin: string): string {
     return `preparedCheck:${schoolPin}:${pupilPin}`
   }
-
 }


### PR DESCRIPTION
Creates a secondary lookup for prepared checks based on checkCode, rather than all services requiring the pupil & school pin.

This was originally conceived in the pupil-api, and has now been moved to the prepare check service, at the point when the checks are created.