### PR TITLE
spike/39361 - cache check forms after first fetch during pin generation

### DIFF
--- a/admin/services/check-form-v2.service.js
+++ b/admin/services/check-form-v2.service.js
@@ -4,6 +4,9 @@ const R = require('ramda')
 const checkFormPresenter = require('../helpers/check-form-presenter')
 const checkFormV2DataService = require('./data-access/check-form-v2.data.service')
 const checkFormsValidator = require('../lib/validator/check-form/check-forms-validator')
+const redisCacheService = require('./data-access/redis-cache.service')
+const redisKeyService = require('./redis-key.service')
+
 const checkFormV2Service = {}
 
 const checkFormTypes = {
@@ -159,6 +162,8 @@ checkFormV2Service.updateCheckWindowForms = async (checkWindow, checkFormType, c
   if (checkFormType === 'familiarisation' && !checkFormUrlSlugs) {
     return checkFormV2DataService.sqlUnassignFamiliarisationForm(checkWindow.id)
   }
+  const formsCacheKey = redisKeyService.getCheckFormsKey(checkWindow.id, isLiveCheckForm)
+  await redisCacheService.drop(formsCacheKey)
   const checkForms = await checkFormV2DataService.sqlFindCheckFormsByUrlSlugs(checkFormUrlSlugs)
   if (!checkForms || !Array.isArray(checkForms) || checkForms.length === 0) {
     throw new Error(`Check forms not found with url slugs ${checkFormUrlSlugs.join(',')}`)

--- a/admin/services/check-form.service.js
+++ b/admin/services/check-form.service.js
@@ -4,7 +4,6 @@ const fs = require('fs')
 const moment = require('moment')
 
 const checkFormDataService = require('../services/data-access/check-form.data.service')
-const checkWindowDataService = require('../services/data-access/check-window.data.service')
 const config = require('../config')
 const random = require('../lib/random-generator')
 
@@ -95,18 +94,6 @@ const checkFormService = {
   },
 
   /**
-   * Un-assign check form from check window.
-   * @param formId the check form to remove
-   * @returns {Promise.<void>}
-   */
-  deleteCheckForm: async (formId) => {
-    // remove assignments from windows
-    await checkFormDataService.sqlRemoveAllWindowAssignments(formId)
-    // mark as deleted
-    return checkFormDataService.sqlMarkFormAsDeleted(formId)
-  },
-
-  /**
    * Return check windows name(s).
    * @param checkWindows
    * @returns {Array}
@@ -190,29 +177,6 @@ const checkFormService = {
   getAssignedFormsForCheckWindow: async (windowId) => {
     const sortDescending = false
     return checkFormDataService.sqlFetchSortedActiveFormsByName(windowId, sortDescending)
-  },
-
-  removeWindowAssignment: async (formId, windowId) => {
-    const promises = [
-      checkFormDataService.sqlFindOneById(formId),
-      checkWindowDataService.sqlFindOneById(windowId)
-    ]
-
-    const [checkForm, checkWindow] = await Promise.all(promises)
-
-    if (!checkForm) {
-      throw new Error(`Invalid checkForm ID: [${formId}]`)
-    }
-    if (!checkWindow) {
-      throw new Error(`Invalid checkWindow ID: [${windowId}]`)
-    }
-
-    // CheckForms can only be unassigned if the check window has not yet started
-    if (checkWindow.checkStartDate.isBefore(moment())) {
-      throw new Error('Forms cannot be unassigned from an active check window')
-    }
-
-    return checkFormDataService.sqlRemoveWindowAssignment(formId, windowId)
   },
 
   getCheckFormsByIds: async (ids) => {

--- a/admin/services/check-start.service/check-start.service.spec.js
+++ b/admin/services/check-start.service/check-start.service.spec.js
@@ -91,6 +91,7 @@ describe('check-start.service', () => {
         })
       spyOn(checkStartDataService, 'sqlStoreBatchConfigs')
       spyOn(redisCacheService, 'get').and.returnValue(Promise.resolve())
+      spyOn(redisCacheService, 'set').and.returnValue(Promise.resolve())
     })
 
     it('throws an error if the pupilIds are not provided', async () => {

--- a/admin/services/check-start.service/check-start.service.spec.js
+++ b/admin/services/check-start.service/check-start.service.spec.js
@@ -12,6 +12,7 @@ const pinGenerationDataService = require('../data-access/pin-generation.data.ser
 const prepareCheckService = require('../prepare-check.service')
 const pupilDataService = require('../data-access/pupil.data.service')
 const sasTokenService = require('../sas-token.service')
+const redisCacheService = require('../data-access/redis-cache.service')
 
 const checkFormMock = {
   id: 100,
@@ -89,6 +90,7 @@ describe('check-start.service', () => {
           3: configService.getBaseConfig()
         })
       spyOn(checkStartDataService, 'sqlStoreBatchConfigs')
+      spyOn(redisCacheService, 'get').and.returnValue(Promise.resolve())
     })
 
     it('throws an error if the pupilIds are not provided', async () => {

--- a/admin/services/data-access/redis-cache.service.js
+++ b/admin/services/data-access/redis-cache.service.js
@@ -31,7 +31,7 @@ const redisCacheService = {}
 redisCacheService.get = async key => {
   redisConnect()
   try {
-    logger.info(`REDIS (get): retrieving ${key}`)
+    logger.debug(`REDIS (get): retrieving ${key}`)
     const cacheEntry = await redis.get(key)
     return unwrap(cacheEntry)
   } catch (err) {
@@ -50,7 +50,7 @@ redisCacheService.get = async key => {
 redisCacheService.set = async (key, value, ttl = undefined) => {
   redisConnect()
   try {
-    logger.info(`REDIS (set): adding ${key} ttl:${ttl}`)
+    logger.debug(`REDIS (set): adding ${key} ttl:${ttl}`)
     const storageItemString = prepareCacheEntry(value)
     if (ttl) {
       await redis.setex(key, ttl, storageItemString)
@@ -81,7 +81,7 @@ redisCacheService.drop = async (cacheKeys = []) => {
     pipeline.del(c)
   })
   await pipeline.exec()
-  logger.info(`REDIS (drop): Dropped \`${cacheKeys.join('`, `')}\``)
+  logger.debug(`REDIS (drop): Dropped \`${cacheKeys.join('`, `')}\``)
   return true
 }
 
@@ -100,13 +100,13 @@ redisCacheService.setMany = async (items) => {
     const item = items[index]
     const storageItem = prepareCacheEntry(item.value)
     if (item.ttl !== undefined) {
-      logger.info(`REDIS (multi:setex): adding ${item.key} ttl:${item.ttl}`)
+      logger.debug(`REDIS (multi:setex): adding ${item.key} ttl:${item.ttl}`)
       multi.setex(item.key, item.ttl, storageItem)
     } else {
       multi.set(item.key, storageItem)
     }
   }
-  logger.info('REDIS (multi:exec)')
+  logger.debug('REDIS (multi:exec)')
   return multi.exec()
 }
 
@@ -122,7 +122,7 @@ redisCacheService.getMany = async (keys) => {
   redisConnect()
   const rawData = await redis.mget(...keys)
   const data = rawData.map(raw => unwrap(raw))
-  logger.info(`(redis) getMany ${keys.join(', ')}`)
+  logger.debug(`(redis) getMany ${keys.join(', ')}`)
   return data
 }
 

--- a/admin/services/data-access/redis-cache.service.js
+++ b/admin/services/data-access/redis-cache.service.js
@@ -31,6 +31,7 @@ const redisCacheService = {}
 redisCacheService.get = async key => {
   redisConnect()
   try {
+    logger.info(`REDIS (get): retrieving ${key}`)
     const cacheEntry = await redis.get(key)
     return unwrap(cacheEntry)
   } catch (err) {
@@ -49,6 +50,7 @@ redisCacheService.get = async key => {
 redisCacheService.set = async (key, value, ttl = undefined) => {
   redisConnect()
   try {
+    logger.info(`REDIS (set): adding ${key} ttl:${ttl}`)
     const storageItemString = prepareCacheEntry(value)
     if (ttl) {
       await redis.setex(key, ttl, storageItemString)

--- a/admin/services/redis-key.service.js
+++ b/admin/services/redis-key.service.js
@@ -37,6 +37,15 @@ const redisKeyService = {
    */
   getPreparedCheckKey (schoolPin, pupilPin) {
     return `preparedCheck:${schoolPin}:${pupilPin}`
+  },
+
+  /**
+   * return the key used to store the check forms
+   * @param {number} checkWindowId
+   * @param {boolean} isLiveCheck
+   */
+  getCheckFormsKey (checkWindowId, isLiveCheck) {
+    return `checkForms:${checkWindowId}:live:${isLiveCheck}`
   }
 }
 

--- a/admin/spec/back-end/service/check-form-v2.service.spec.js
+++ b/admin/spec/back-end/service/check-form-v2.service.spec.js
@@ -7,6 +7,7 @@ const checkFormV2DataService = require('../../../services/data-access/check-form
 const checkFormV2Service = require('../../../services/check-form-v2.service')
 const checkFormsValidator = require('../../../lib/validator/check-form/check-forms-validator')
 const ValidationError = require('../../../lib/validation-error')
+const redisCacheService = require('../../../services/data-access/redis-cache.service')
 
 describe('check-form-v2.service', () => {
   describe('saveCheckForms', () => {
@@ -148,6 +149,7 @@ describe('check-form-v2.service', () => {
       spyOn(checkFormV2DataService, 'sqlFindCheckFormsByUrlSlugs').and.returnValue([{ id: 1 }])
       spyOn(checkFormV2DataService, 'sqlUnassignFamiliarisationForm')
       spyOn(checkFormV2DataService, 'sqlAssignFormsToCheckWindow')
+      spyOn(redisCacheService, 'drop').and.returnValue(Promise.resolve())
       const checkWindow = { id: 1, urlSlug: 'urlSlug' }
       const checkFormType = 'live'
       const checkFormUrlSlugs = ['urlSlug1', 'urlSlug2']
@@ -160,6 +162,7 @@ describe('check-form-v2.service', () => {
       spyOn(checkFormV2DataService, 'sqlFindCheckFormsByUrlSlugs')
       spyOn(checkFormV2DataService, 'sqlUnassignFamiliarisationForm')
       spyOn(checkFormV2DataService, 'sqlAssignFormsToCheckWindow')
+      spyOn(redisCacheService, 'drop').and.returnValue(Promise.resolve())
       const checkWindow = {}
       const checkFormType = 'live'
       const checkFormUrlSlugs = ['urlSlug1', 'urlSlug2']
@@ -177,6 +180,7 @@ describe('check-form-v2.service', () => {
       spyOn(checkFormV2DataService, 'sqlFindCheckFormsByUrlSlugs').and.returnValue([])
       spyOn(checkFormV2DataService, 'sqlUnassignFamiliarisationForm')
       spyOn(checkFormV2DataService, 'sqlAssignFormsToCheckWindow')
+      spyOn(redisCacheService, 'drop').and.returnValue(Promise.resolve())
       const checkWindow = { id: 1, urlSlug: 'urlSlug' }
       const checkFormType = 'live'
       const checkFormUrlSlugs = ['urlSlug1', 'urlSlug2']
@@ -194,6 +198,7 @@ describe('check-form-v2.service', () => {
       spyOn(checkFormV2DataService, 'sqlFindCheckFormsByUrlSlugs').and.returnValue(Promise.reject(new Error('error')))
       spyOn(checkFormV2DataService, 'sqlUnassignFamiliarisationForm')
       spyOn(checkFormV2DataService, 'sqlAssignFormsToCheckWindow')
+      spyOn(redisCacheService, 'drop').and.returnValue(Promise.resolve())
       const checkWindow = { id: 1, urlSlug: 'urlSlug' }
       const checkFormType = 'live'
       const checkFormUrlSlugs = ['urlSlug1', 'urlSlug2']
@@ -211,6 +216,7 @@ describe('check-form-v2.service', () => {
       spyOn(checkFormV2DataService, 'sqlFindCheckFormsByUrlSlugs').and.returnValue([{ id: 1 }])
       spyOn(checkFormV2DataService, 'sqlUnassignFamiliarisationForm')
       spyOn(checkFormV2DataService, 'sqlAssignFormsToCheckWindow').and.returnValue(Promise.reject(new Error('error')))
+      spyOn(redisCacheService, 'drop').and.returnValue(Promise.resolve())
       const checkWindow = { id: 1, urlSlug: 'urlSlug' }
       const checkFormType = 'live'
       const checkFormUrlSlugs = ['urlSlug1', 'urlSlug2']


### PR DESCRIPTION
Allocated Check forms are static during a check window and are only modified in exceptional circumstances.   They are fetched from the database every time a teacher generates one or more pins.

- Cache the check forms for 1 month after first fetch.  
- Drop cache when check window form assignments are modified.
- remove obsolete check form modification code from old check form service