### PR TITLE
Add createdby_userId during check creation

### DIFF
--- a/admin/controllers/pupil-pin.js
+++ b/admin/controllers/pupil-pin.js
@@ -154,6 +154,7 @@ const postGeneratePins = async function postGeneratePins (req, res, next) {
       pupilsList,
       req.user.School,
       req.user.schoolId,
+      req.user.id,
       isLiveCheck,
       school.timezone,
       checkWindowData

--- a/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE [mtc_admin].[check]
+ADD createdBy_userId INT NOT NULL
+CONSTRAINT [FK_check_createdBy_userId_fk] FOREIGN KEY([createdBy_userId])
+REFERENCES [mtc_admin].[user] ([id])

--- a/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE [mtc_admin].[check]
-ADD createdBy_userId INT NULL
+ADD createdBy_userId INT NULL;
 CONSTRAINT [FK_check_createdBy_userId] FOREIGN KEY([createdBy_userId])
-REFERENCES [mtc_admin].[user] ([id])
+REFERENCES [mtc_admin].[user] ([id]);

--- a/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE [mtc_admin].[check]
-ADD createdBy_userId INT NOT NULL
+ADD createdBy_userId INT NULL
 CONSTRAINT [FK_check_createdBy_userId] FOREIGN KEY([createdBy_userId])
 REFERENCES [mtc_admin].[user] ([id])

--- a/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE [mtc_admin].[check]
-ADD createdBy_userId INT NULL;
+ADD createdBy_userId INT NULL
 CONSTRAINT [FK_check_createdBy_userId] FOREIGN KEY([createdBy_userId])
 REFERENCES [mtc_admin].[user] ([id]);

--- a/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.do.update-check-add-created-by-user-id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE [mtc_admin].[check]
 ADD createdBy_userId INT NOT NULL
-CONSTRAINT [FK_check_createdBy_userId_fk] FOREIGN KEY([createdBy_userId])
+CONSTRAINT [FK_check_createdBy_userId] FOREIGN KEY([createdBy_userId])
 REFERENCES [mtc_admin].[user] ([id])

--- a/admin/data/sql/migrations/20200318120158.undo.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.undo.update-check-add-created-by-user-id.sql
@@ -1,4 +1,4 @@
 ALTER TABLE [mtc_admin].[check]
-DROP CONSTRAINT [FK_check_createdBy_userId_fk];
+DROP CONSTRAINT [FK_check_createdBy_userId];
 ALTER TABLE [mtc_admin].[check]
 DROP COLUMN createdBy_userId;

--- a/admin/data/sql/migrations/20200318120158.undo.update-check-add-created-by-user-id.sql
+++ b/admin/data/sql/migrations/20200318120158.undo.update-check-add-created-by-user-id.sql
@@ -1,0 +1,4 @@
+ALTER TABLE [mtc_admin].[check]
+DROP CONSTRAINT [FK_check_createdBy_userId_fk];
+ALTER TABLE [mtc_admin].[check]
+DROP COLUMN createdBy_userId;

--- a/admin/data/sql/migrations/20200318133108.do.drop-spcreatechecks.sql
+++ b/admin/data/sql/migrations/20200318133108.do.drop-spcreatechecks.sql
@@ -1,0 +1,1 @@
+DROP PROCEDURE IF EXISTS [mtc_admin].[spCreateChecks];

--- a/admin/data/sql/migrations/20200318133108.undo.drop-spcreatechecks.sql
+++ b/admin/data/sql/migrations/20200318133108.undo.drop-spcreatechecks.sql
@@ -1,0 +1,174 @@
+CREATE OR ALTER PROCEDURE [mtc_admin].[spCreateChecks]
+@TVP [mtc_admin].[CheckTableType] READONLY
+AS
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+SET CONCAT_NULL_YIELDS_NULL ON
+SET ANSI_WARNINGS ON
+SET ANSI_PADDING ON
+
+-- only proceed if school has an active pin
+DECLARE @school_id int
+SELECT TOP 1 @school_id = school_id FROM @TVP
+IF NOT EXISTS (SELECT id FROM mtc_admin.school
+    WHERE (id = @school_id AND pin IS NOT NULL
+    AND (pinExpiresAt IS NOT NULL AND pinExpiresAt > GETUTCDATE())))
+    RAISERROR ('50001: School has no valid pin', 18, 1)
+
+-- Connection pooling is enabled - make sure we are not in an existing transaction
+IF @@TRANCOUNT <> 0  -- Rollback old transactions before starting another
+    ROLLBACK TRANSACTION
+
+BEGIN TRY
+    BEGIN TRANSACTION
+
+        DECLARE checkArgsList CURSOR
+            FOR SELECT pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id
+                FROM @TVP
+            FOR READ ONLY
+
+        DECLARE @pupilId int
+        DECLARE @checkFormId int
+        DECLARE @checkWindowId int
+        DECLARE @isLiveCheck bit
+        DECLARE @pinExpiresAt datetimeoffset
+        DECLARE @schoolId int
+        DEClARE @checkId int
+        DECLARE @output TABLE (id int);
+        DECLARE @isRestart bit;
+        DECLARE @pupilRestartId int;
+
+        OPEN checkArgsList
+        FETCH checkArgsList INTO @pupilId, @checkFormId, @checkWindowId, @isLiveCheck, @pinExpiresAt, @schoolId
+        WHILE (@@FETCH_STATUS = 0) BEGIN
+
+            -- Create the check
+            INSERT INTO [mtc_admin].[check]
+            (pupil_id, checkForm_id, checkWindow_id, isLiveCheck)
+            VALUES (@pupilId, @checkFormId, @checkWindowId, @isLiveCheck);
+
+            -- Get the check.id we just inserted
+            SET @checkId = SCOPE_IDENTITY();
+
+            -- Assign a pin to the check
+            INSERT INTO [mtc_admin].[checkPin] (school_id, check_id, pinExpiresAt, pin_id)
+            VALUES (
+                @schoolId,
+                @checkId,
+                @pinExpiresAt,
+                (SELECT TOP 1 id
+                   FROM (SELECT id
+                           FROM mtc_admin.pin EXCEPT
+                         SELECT pin_id
+                           FROM mtc_admin.checkPin
+                          WHERE school_id = @schoolId) as vew
+                  ORDER BY NEWID())
+            );
+
+
+            IF @isLiveCheck = 1
+                BEGIN
+                    -- If the pupil is consuming a restart we need to mark it in the restart table
+                    SELECT
+                            @isRestart = restartAvailable
+                    FROM [mtc_admin].[pupil]
+                    WHERE id = @pupilId;
+
+                    IF @isRestart = 1
+                        BEGIN
+                            -- Find the pupilRestart id so we can update it
+                            SELECT
+                                @pupilRestartId = id
+                            FROM
+                                [mtc_admin].[pupilRestart]
+                            WHERE id = (
+                                SELECT max(id)
+                                FROM [mtc_admin].[pupilRestart]
+                                WHERE pupil_id = @pupilId
+                                  AND  isDeleted = 0
+                            );
+
+                            IF @pupilRestartId IS NULL
+                                THROW 51000, 'Failed to find open pupilRestart for pupil', 1;
+
+                            -- Consume the pupil restart
+                            UPDATE [mtc_admin].[pupilRestart]
+                            SET check_id = @checkId
+                            WHERE id = @pupilRestartId;
+                        END
+
+                    -- Update the pupil state
+                    UPDATE [mtc_admin].[pupil]
+                    SET currentCheckId = @checkId,
+                        checkComplete = 0,
+                        restartAvailable = 0
+                    WHERE id = @pupilId;
+                END
+
+            -- Store the check.id in the output table
+            INSERT INTO @output (id) (SELECT @checkId);
+
+            FETCH checkArgsList INTO @pupilId, @checkFormId, @checkWindowId, @isLiveCheck, @pinExpiresAt, @schoolId
+        END
+
+    COMMIT TRANSACTION
+
+    -- OUTPUT newly created checks to the caller
+    SELECT
+      chk.id as check_id,
+      chk.checkCode as check_checkCode,
+      chk.isLiveCheck as check_isLiveCheck,
+      pin.val as pupil_pin,
+      cp.pinExpiresAt as pupil_pinExpiresAt,
+      pupil.id as pupil_id,
+      pupil.foreName as pupil_foreName,
+      pupil.lastName as pupil_lastName,
+      pupil.foreNameAlias as pupil_foreNameAlias,
+      pupil.lastNameAlias as pupil_lastNameAlias,
+      pupil.dateOfBirth as pupil_dateOfBirth,
+      pupil.urlSlug as pupil_uuid,
+      pupil.jwtToken as pupil_jwtToken,
+      checkForm.id as checkForm_id,
+      checkForm.formData as checkForm_formData,
+      school.id as school_id,
+      school.urlSlug as school_uuid,
+      school.name as school_name,
+      school.pin as school_pin,
+      school.pinExpiresAt as school_pinExpiresAt,
+      ISNULL(sce.timezone, 'Europe/London') as timezone
+    FROM
+      [mtc_admin].[check] chk
+      INNER JOIN [mtc_admin].[pupil] pupil ON (chk.pupil_id = pupil.id)
+      INNER JOIN [mtc_admin].[checkForm] checkForm ON (chk.checkForm_id = checkForm.id)
+      INNER JOIN [mtc_admin].[school] school on (pupil.school_id = school.id)
+      INNER JOIN [mtc_admin].[checkPin] cp on (chk.id = cp.check_id)
+      INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+      LEFT JOIN [mtc_admin].sce ON (sce.school_id = school.id)
+    WHERE chk.id IN (SELECT id from @output);
+
+    CLOSE checkArgsList
+    DEALLOCATE checkArgsList
+
+END TRY
+BEGIN CATCH
+    IF (@@TRANCOUNT > 0)
+        BEGIN
+            ROLLBACK TRANSACTION
+            PRINT 'Error detected, all changes reversed'
+        END
+    DECLARE @ErrorMessage NVARCHAR(4000);
+    DECLARE @ErrorSeverity INT;
+    DECLARE @ErrorState INT;
+
+    SELECT @ErrorMessage = ERROR_MESSAGE(),
+           @ErrorSeverity = ERROR_SEVERITY(),
+           @ErrorState = ERROR_STATE();
+
+    -- Use RAISERROR inside the CATCH block to return
+    -- error information about the original error that
+    -- caused execution to jump to the CATCH block.
+    RAISERROR (@ErrorMessage, -- Message text.
+        @ErrorSeverity, -- Severity.
+        @ErrorState -- State.
+        );
+END CATCH

--- a/admin/data/sql/migrations/20200318133218.do.drop-check-table-type.sql
+++ b/admin/data/sql/migrations/20200318133218.do.drop-check-table-type.sql
@@ -1,0 +1,1 @@
+DROP TYPE IF EXISTS [mtc_admin].[checkTableType];

--- a/admin/data/sql/migrations/20200318133218.undo.drop-check-table-type.sql
+++ b/admin/data/sql/migrations/20200318133218.undo.drop-check-table-type.sql
@@ -1,0 +1,8 @@
+CREATE TYPE [mtc_admin].[checkTableType] AS TABLE (
+  pupil_id int,
+  checkForm_id int,
+  checkWindow_id int,
+  isLiveCheck bit,
+  pinExpiresAt datetimeoffset(3),
+  school_id int
+);

--- a/admin/data/sql/migrations/20200318134251.do.recreate-check-table-type-with-user-id.sql
+++ b/admin/data/sql/migrations/20200318134251.do.recreate-check-table-type-with-user-id.sql
@@ -1,0 +1,9 @@
+CREATE TYPE [mtc_admin].[checkTableType] AS TABLE (
+  pupil_id int,
+  checkForm_id int,
+  checkWindow_id int,
+  isLiveCheck bit,
+  pinExpiresAt datetimeoffset(3),
+  school_id int,
+  createdBy_userId int
+);

--- a/admin/data/sql/migrations/20200318134251.undo.recreate-check-table-type-with-user-id.sql
+++ b/admin/data/sql/migrations/20200318134251.undo.recreate-check-table-type-with-user-id.sql
@@ -1,0 +1,1 @@
+DROP TYPE IF EXISTS [mtc_admin].[checkTableType];

--- a/admin/data/sql/migrations/20200318134838.do.recreate-spcreatechecks-with-user-id.sql
+++ b/admin/data/sql/migrations/20200318134838.do.recreate-spcreatechecks-with-user-id.sql
@@ -1,0 +1,176 @@
+CREATE OR ALTER PROCEDURE [mtc_admin].[spCreateChecks]
+@TVP [mtc_admin].[CheckTableType] READONLY
+AS
+SET ANSI_NULLS ON
+SET QUOTED_IDENTIFIER ON
+SET CONCAT_NULL_YIELDS_NULL ON
+SET ANSI_WARNINGS ON
+SET ANSI_PADDING ON
+
+-- only proceed if school has an active pin
+DECLARE @school_id int
+SELECT TOP 1 @school_id = school_id FROM @TVP
+IF NOT EXISTS (SELECT id FROM mtc_admin.school
+    WHERE (id = @school_id AND pin IS NOT NULL
+    AND (pinExpiresAt IS NOT NULL AND pinExpiresAt > GETUTCDATE())))
+    RAISERROR ('50001: School has no valid pin', 18, 1)
+
+-- Connection pooling is enabled - make sure we are not in an existing transaction
+IF @@TRANCOUNT <> 0  -- Rollback old transactions before starting another
+    ROLLBACK TRANSACTION
+
+BEGIN TRY
+    BEGIN TRANSACTION
+
+        DECLARE checkArgsList CURSOR
+            FOR SELECT pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id, createdBy_userId
+                FROM @TVP
+            FOR READ ONLY
+
+        DECLARE @pupilId int
+        DECLARE @checkFormId int
+        DECLARE @checkWindowId int
+        DECLARE @isLiveCheck bit
+        DECLARE @pinExpiresAt datetimeoffset
+        DECLARE @schoolId int
+        DECLARE @createdBy_userId int
+        DEClARE @checkId int
+        DECLARE @output TABLE (id int);
+        DECLARE @isRestart bit;
+        DECLARE @pupilRestartId int;
+
+        OPEN checkArgsList
+        FETCH checkArgsList INTO @pupilId, @checkFormId, @checkWindowId, @isLiveCheck, @pinExpiresAt, @schoolId, @createdBy_userId
+        WHILE (@@FETCH_STATUS = 0) BEGIN
+
+            -- Create the check
+            INSERT INTO [mtc_admin].[check]
+            (pupil_id, checkForm_id, checkWindow_id, isLiveCheck, createdBy_userId)
+            VALUES (@pupilId, @checkFormId, @checkWindowId, @isLiveCheck, @createdBy_userId);
+
+            -- Get the check.id we just inserted
+            SET @checkId = SCOPE_IDENTITY();
+
+            -- Assign a pin to the check
+            INSERT INTO [mtc_admin].[checkPin] (school_id, check_id, pinExpiresAt, pin_id)
+            VALUES (
+                @schoolId,
+                @checkId,
+                @pinExpiresAt,
+                (SELECT TOP 1 id
+                   FROM (SELECT id
+                           FROM mtc_admin.pin EXCEPT
+                         SELECT pin_id
+                           FROM mtc_admin.checkPin
+                          WHERE school_id = @schoolId) as vew
+                  ORDER BY NEWID())
+            );
+
+
+            IF @isLiveCheck = 1
+                BEGIN
+                    -- If the pupil is consuming a restart we need to mark it in the restart table
+                    SELECT
+                            @isRestart = restartAvailable
+                    FROM [mtc_admin].[pupil]
+                    WHERE id = @pupilId;
+
+                    IF @isRestart = 1
+                        BEGIN
+                            -- Find the pupilRestart id so we can update it
+                            SELECT
+                                @pupilRestartId = id
+                            FROM
+                                [mtc_admin].[pupilRestart]
+                            WHERE id = (
+                                SELECT max(id)
+                                FROM [mtc_admin].[pupilRestart]
+                                WHERE pupil_id = @pupilId
+                                  AND  isDeleted = 0
+                            );
+
+                            IF @pupilRestartId IS NULL
+                                THROW 51000, 'Failed to find open pupilRestart for pupil', 1;
+
+                            -- Consume the pupil restart
+                            UPDATE [mtc_admin].[pupilRestart]
+                            SET check_id = @checkId
+                            WHERE id = @pupilRestartId;
+                        END
+
+                    -- Update the pupil state
+                    UPDATE [mtc_admin].[pupil]
+                    SET currentCheckId = @checkId,
+                        checkComplete = 0,
+                        restartAvailable = 0
+                    WHERE id = @pupilId;
+                END
+
+            -- Store the check.id in the output table
+            INSERT INTO @output (id) (SELECT @checkId);
+
+            FETCH checkArgsList INTO @pupilId, @checkFormId, @checkWindowId, @isLiveCheck, @pinExpiresAt, @schoolId, @createdBy_userId
+        END
+
+    COMMIT TRANSACTION
+
+    -- OUTPUT newly created checks to the caller
+    SELECT
+      chk.id as check_id,
+      chk.checkCode as check_checkCode,
+      chk.isLiveCheck as check_isLiveCheck,
+      chk.createdBy_userId as check_createdBy_userId,
+      pin.val as pupil_pin,
+      cp.pinExpiresAt as pupil_pinExpiresAt,
+      pupil.id as pupil_id,
+      pupil.foreName as pupil_foreName,
+      pupil.lastName as pupil_lastName,
+      pupil.foreNameAlias as pupil_foreNameAlias,
+      pupil.lastNameAlias as pupil_lastNameAlias,
+      pupil.dateOfBirth as pupil_dateOfBirth,
+      pupil.urlSlug as pupil_uuid,
+      pupil.jwtToken as pupil_jwtToken,
+      checkForm.id as checkForm_id,
+      checkForm.formData as checkForm_formData,
+      school.id as school_id,
+      school.urlSlug as school_uuid,
+      school.name as school_name,
+      school.pin as school_pin,
+      school.pinExpiresAt as school_pinExpiresAt,
+      ISNULL(sce.timezone, 'Europe/London') as timezone
+    FROM
+      [mtc_admin].[check] chk
+      INNER JOIN [mtc_admin].[pupil] pupil ON (chk.pupil_id = pupil.id)
+      INNER JOIN [mtc_admin].[checkForm] checkForm ON (chk.checkForm_id = checkForm.id)
+      INNER JOIN [mtc_admin].[school] school on (pupil.school_id = school.id)
+      INNER JOIN [mtc_admin].[checkPin] cp on (chk.id = cp.check_id)
+      INNER JOIN [mtc_admin].[pin] pin ON (cp.pin_id = pin.id)
+      LEFT JOIN [mtc_admin].sce ON (sce.school_id = school.id)
+    WHERE chk.id IN (SELECT id from @output);
+
+    CLOSE checkArgsList
+    DEALLOCATE checkArgsList
+
+END TRY
+BEGIN CATCH
+    IF (@@TRANCOUNT > 0)
+        BEGIN
+            ROLLBACK TRANSACTION
+            PRINT 'Error detected, all changes reversed'
+        END
+    DECLARE @ErrorMessage NVARCHAR(4000);
+    DECLARE @ErrorSeverity INT;
+    DECLARE @ErrorState INT;
+
+    SELECT @ErrorMessage = ERROR_MESSAGE(),
+           @ErrorSeverity = ERROR_SEVERITY(),
+           @ErrorState = ERROR_STATE();
+
+    -- Use RAISERROR inside the CATCH block to return
+    -- error information about the original error that
+    -- caused execution to jump to the CATCH block.
+    RAISERROR (@ErrorMessage, -- Message text.
+        @ErrorSeverity, -- Severity.
+        @ErrorState -- State.
+        );
+END CATCH

--- a/admin/data/sql/migrations/20200318134838.undo.recreate-spcreatechecks-with-user-id.sql
+++ b/admin/data/sql/migrations/20200318134838.undo.recreate-spcreatechecks-with-user-id.sql
@@ -1,0 +1,1 @@
+DROP PROCEDURE IF EXISTS [mtc_admin].[spCreateChecks];

--- a/admin/services/check-start.service/check-start.service.js
+++ b/admin/services/check-start.service/check-start.service.js
@@ -202,7 +202,7 @@ checkStartService.initialisePupilCheck = async function (
   usedFormIds,
   isLiveCheck,
   userId,
-  schoolId = null,
+  schoolId,
   schoolTimezone = null
 ) {
   const checkForm = await checkFormService.allocateCheckForm(

--- a/admin/services/check-start.service/check-start.service.js
+++ b/admin/services/check-start.service/check-start.service.js
@@ -166,6 +166,23 @@ checkStartService.prepareCheck2 = async function (
   return this.storeCheckConfigs(pupilChecks, newChecks)
 }
 
+checkStartService.storeCheckConfigs = async function (preparedChecks, newChecks) {
+  if (!Array.isArray(preparedChecks)) {
+    throw new Error('`preparedChecks is not an array')
+  }
+  if (!preparedChecks.length) {
+    return
+  }
+  const config = preparedChecks.map(pcheck => {
+    return {
+      checkCode: pcheck.check_checkCode,
+      config: pcheck.config,
+      checkId: newChecks.find(check => check.check_checkCode === pcheck.checkCode).check_id
+    }
+  })
+  checkStartDataService.sqlStoreBatchConfigs(config)
+}
+
 /**
  * Return a new pupil check object. Saving the data is handled in a batch process by the caller
  * @param {number} pupilId
@@ -218,23 +235,6 @@ checkStartService.initialisePupilCheck = async function (
   // checkCode will be created by the database on insert
   // checkStatus_id will default to '1' - 'New'
   return checkData
-}
-
-checkStartService.storeCheckConfigs = async function (preparedChecks, newChecks) {
-  if (!Array.isArray(preparedChecks)) {
-    throw new Error('`preparedChecks is not an array')
-  }
-  if (!preparedChecks.length) {
-    return
-  }
-  const config = preparedChecks.map(pcheck => {
-    return {
-      checkCode: pcheck.check_checkCode,
-      config: pcheck.config,
-      checkId: newChecks.find(check => check.check_checkCode === pcheck.checkCode).check_id
-    }
-  })
-  checkStartDataService.sqlStoreBatchConfigs(config)
 }
 
 /**

--- a/admin/services/check-start.service/check-start.service.spec.js
+++ b/admin/services/check-start.service/check-start.service.spec.js
@@ -28,6 +28,7 @@ describe('check-start.service', () => {
   const service = checkStartService
   const dfeNumber = 9991999
   const schoolId = 42
+  const userId = 5
 
   const mockPupils = [
     { id: 1 },
@@ -110,7 +111,7 @@ describe('check-start.service', () => {
 
     test('throws an error if the pupilIds are not provided', async () => {
       try {
-        await checkStartService.prepareCheck2(undefined, dfeNumber, schoolId, true, checkWindowMock)
+        await checkStartService.prepareCheck2(undefined, dfeNumber, schoolId, userId, true, checkWindowMock)
         fail('expected to throw')
       } catch (error) {
         expect(error.message).toBe('pupilIds is required')
@@ -119,17 +120,26 @@ describe('check-start.service', () => {
 
     test('throws an error if the schoolId is not provided', async () => {
       try {
-        await checkStartService.prepareCheck2(pupilIds, dfeNumber, undefined, true, checkWindowMock)
+        await checkStartService.prepareCheck2(pupilIds, dfeNumber, undefined, userId, true, checkWindowMock)
         fail('expected to throw')
       } catch (error) {
         expect(error.message).toBe('schoolId is required')
       }
     })
 
+    test('throws an error if the userId is not provided', async () => {
+      try {
+        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, undefined, true, checkWindowMock)
+        fail('expected to throw')
+      } catch (error) {
+        expect(error.message).toBe('userId is required')
+      }
+    })
+
     test('throws an error if provided with pupilIds that are not a part of the school', async () => {
       try {
         spyOn(logger, 'error')
-        await checkStartService.prepareCheck2(pupilIdsHackAttempt, dfeNumber, schoolId, true, checkWindowMock)
+        await checkStartService.prepareCheck2(pupilIdsHackAttempt, dfeNumber, schoolId, userId, true, checkWindowMock)
         fail('expected to throw')
       } catch (error) {
         expect(error.message).toBe('Validation failed')
@@ -137,18 +147,18 @@ describe('check-start.service', () => {
     })
 
     test('calls sqlFindPupilsEligibleForPinGenerationById to find pupils', async () => {
-      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
       expect(checkStartDataService.sqlFindPupilsEligibleForPinGenerationById).toHaveBeenCalledTimes(1)
     })
 
     test('calls initialisePupilCheck to randomly select a check form', async () => {
-      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
       expect(checkStartService.initialisePupilCheck).toHaveBeenCalledTimes(mockPupils.length)
       expect(pinGenerationDataService.sqlCreateBatch).toHaveBeenCalledTimes(1)
     })
 
     test('adds config to the database', async () => {
-      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
       // pupil status re-calc and prepare-check queues
       expect(checkStartDataService.sqlStoreBatchConfigs).toHaveBeenCalledTimes(1)
     })
@@ -181,7 +191,7 @@ describe('check-start.service', () => {
         throw new Error('50001: no school pin found')
       })
       try {
-        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
         fail('error should have been thrown')
       } catch (error) {
         expect(error).toBeDefined()
@@ -197,7 +207,7 @@ describe('check-start.service', () => {
         throw new Error('50001: no school pin found')
       })
       try {
-        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
         fail('error should have been thrown')
       } catch (error) {
         expect(error).toBeDefined()
@@ -215,7 +225,7 @@ describe('check-start.service', () => {
         throw err
       })
       try {
-        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+        await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
         fail('error should have been thrown')
       } catch (error) {
         expect(error).toBeDefined()
@@ -234,7 +244,7 @@ describe('check-start.service', () => {
       spyOn(pinGenerationDataService, 'sqlCreateBatch').and.callFake(() => {
         return Promise.resolve(checksWithNoSchoolPins)
       })
-      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, true, null, checkWindowMock)
+      await checkStartService.prepareCheck2(pupilIds, dfeNumber, schoolId, userId, true, null, checkWindowMock)
       expect(schoolPinService.generateSchoolPin).not.toHaveBeenCalled()
     })
   })
@@ -245,7 +255,7 @@ describe('check-start.service', () => {
     })
     test('calls generatePinTimestamp to generate pinExpiresAt for a pupil', async () => {
       spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-      await service.initialisePupilCheck(1, checkWindowMock, [], [], true)
+      await service.initialisePupilCheck(1, checkWindowMock, [], [], true, userId)
       expect(pinService.generatePinTimestamp).toHaveBeenCalledTimes(1)
     })
     test('calls allocateCheckForm for a pupil', async () => {
@@ -271,16 +281,18 @@ describe('check-start.service', () => {
         expect({}.hasOwnProperty.call(c, 'pupil_id'))
         expect({}.hasOwnProperty.call(c, 'checkWindow_id'))
         expect({}.hasOwnProperty.call(c, 'checkForm_id'))
+        expect({}.hasOwnProperty.call(c, 'createdBy_userId'))
       })
     })
 
     describe('for test pins', () => {
       test('returns a check object, ready to be inserted into the db', async () => {
         spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, false)
+        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, false, userId)
         expect({}.hasOwnProperty.call(c, 'pupil_id'))
         expect({}.hasOwnProperty.call(c, 'checkWindow_id'))
         expect({}.hasOwnProperty.call(c, 'checkForm_id'))
+        expect({}.hasOwnProperty.call(c, 'createdBy_userId'))
       })
     })
   })

--- a/admin/services/check-start.service/check-start.service.spec.js
+++ b/admin/services/check-start.service/check-start.service.spec.js
@@ -255,19 +255,19 @@ describe('check-start.service', () => {
     })
     test('calls generatePinTimestamp to generate pinExpiresAt for a pupil', async () => {
       spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-      await service.initialisePupilCheck(1, checkWindowMock, [], [], true, userId)
+      await service.initialisePupilCheck(1, checkWindowMock, [], [], true, userId, schoolId)
       expect(pinService.generatePinTimestamp).toHaveBeenCalledTimes(1)
     })
     test('calls allocateCheckForm for a pupil', async () => {
       spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-      await service.initialisePupilCheck(1, checkWindowMock, [], [], true)
+      await service.initialisePupilCheck(1, checkWindowMock, [], [], true, userId, schoolId)
       expect(checkFormService.allocateCheckForm).toHaveBeenCalledTimes(1)
     })
 
     test('throws an error if a checkform is not returned', async () => {
       spyOn(checkFormService, 'allocateCheckForm').and.returnValue(null)
       try {
-        await service.initialisePupilCheck(1, checkWindowMock, [], [], true)
+        await service.initialisePupilCheck(1, checkWindowMock, [], [], true, userId, schoolId)
         fail('expected to throw')
       } catch (error) {
         expect(error.message).toBe('CheckForm not allocated')
@@ -277,7 +277,7 @@ describe('check-start.service', () => {
     describe('for live pins', () => {
       test('returns a check object, ready to be inserted into the db', async () => {
         spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, true)
+        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, true, userId, schoolId)
         expect({}.hasOwnProperty.call(c, 'pupil_id'))
         expect({}.hasOwnProperty.call(c, 'checkWindow_id'))
         expect({}.hasOwnProperty.call(c, 'checkForm_id'))
@@ -288,7 +288,7 @@ describe('check-start.service', () => {
     describe('for test pins', () => {
       test('returns a check object, ready to be inserted into the db', async () => {
         spyOn(checkFormService, 'allocateCheckForm').and.returnValue(checkFormMock)
-        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, false, userId)
+        const c = await service.initialisePupilCheck(1, checkWindowMock, undefined, undefined, false, userId, schoolId)
         expect({}.hasOwnProperty.call(c, 'pupil_id'))
         expect({}.hasOwnProperty.call(c, 'checkWindow_id'))
         expect({}.hasOwnProperty.call(c, 'checkForm_id'))

--- a/admin/services/data-access/pin-generation.data.service.js
+++ b/admin/services/data-access/pin-generation.data.service.js
@@ -43,7 +43,7 @@ const serviceToExport = {
    * Batch create checks with pins, now using a stored procedure
    * A pin will be randomly allocated
    *
-   * @param {[{pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id}]} checks - array of check objects to create
+   * @param {[{pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id, createdBy_userId}]} checks - array of check objects to create
    * @return {Promise<object>}
    */
   sqlCreateBatch: async (checks) => {
@@ -52,7 +52,7 @@ const serviceToExport = {
         (pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id)
         VALUES`
     const inserts = checks.map((check, index) => {
-      return `(@pupilId${index}, @checkFormId${index}, @checkWindowId${index}, @isLiveCheck${index}, @pinExpiresAt${index}, @schoolId${index})`
+      return `(@pupilId${index}, @checkFormId${index}, @checkWindowId${index}, @isLiveCheck${index}, @pinExpiresAt${index}, @schoolId${index}, @createdBy_userId${index})`
     })
     const params = []
     checks.map((check, index) => {
@@ -62,6 +62,7 @@ const serviceToExport = {
       params.push({ name: `isLiveCheck${index}`, value: check.isLiveCheck, type: TYPES.Bit })
       params.push({ name: `pinExpiresAt${index}`, value: check.pinExpiresAt.toDate(), type: TYPES.DateTimeOffset })
       params.push({ name: `schoolId${index}`, value: check.school_id, type: TYPES.Int })
+      params.push({ name: `createdBy_userId${index}`, value: check.createdBy_userId, type: TYPES.Int })
     })
     const exec = 'EXEC [mtc_admin].[spCreateChecks] @tvp'
     const insertSql = insertHeader + inserts.join(',\n')

--- a/admin/services/data-access/pin-generation.data.service.js
+++ b/admin/services/data-access/pin-generation.data.service.js
@@ -49,7 +49,7 @@ const serviceToExport = {
   sqlCreateBatch: async (checks) => {
     const declareTable = 'declare @tvp as [mtc_admin].CheckTableType'
     const insertHeader = `INSERT into @tvp
-        (pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id)
+        (pupil_id, checkForm_id, checkWindow_id, isLiveCheck, pinExpiresAt, school_id, createdBy_userId)
         VALUES`
     const inserts = checks.map((check, index) => {
       return `(@pupilId${index}, @checkFormId${index}, @checkWindowId${index}, @isLiveCheck${index}, @pinExpiresAt${index}, @schoolId${index}, @createdBy_userId${index})`

--- a/admin/views/privacy.ejs
+++ b/admin/views/privacy.ejs
@@ -2,119 +2,124 @@
 <main class="govuk-main-wrapper" id="main-content" role="main">
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <h1 class="govuk-heading-xl">Privacy notice</h1>
+            <h1 class="govuk-heading-xl">Privacy notice: multiplication tables check (MTC)</h1>
             <%- partial('partials/_gds_session_expiry') %>
 
 
 
             <ul class="govuk-list">
                 <li>Contents</li>
-                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#overview">Overview</a></li>
-                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#data-collection-and-access">What data will be collected and who can
-                        access it?</a></li>
-                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#retaining-personal-data">How long will we keep your data?</a></li>
-                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#legal">What is the legal basis for collecting and processing data?</a></li>
-                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#contact">Who can I contact about the use of personal data?</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#who-we-are">Who we are</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#how-we-will-use-information">How we will use your information
+                    </a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#nature-personal-data">The nature of personal data we will be using</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#legal">Why our use of your pupils’ personal data is lawful</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#personal-data-available">Who we will make your pupils’ personal data available to</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#personal-data">How long we will keep your pupils’ personal data</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#rights">Your data protection rights</a></li>
+                <li class="govuk-list-item--dashed"><a class="govuk-link" href="#last-updated">Last updated</a></li>
             </ul>
 
             <hr />
             <br />
-            <div id="overview">
-                <h3 class="govuk-heading-m">Overview</h3>
-                <p>
-                    The Standards and Testing Agency (STA) will use the results of the final 2019 multiplication tables check (MTC) trial and national pilot to:
+            <div id="who-we-are">
+                <h3 class="govuk-heading-m">Who we are</h3>
+                <p class="govuk-body">
+                    This work is being carried out by the Standards and Testing Agency (STA) which is part of the Department for Education (DfE).
+                    For the purpose of data protection legislation, DfE is the data controller for the personal data processed as part of MTC.
+                </p>
+            </div>
+            <div id="how-we-will-use-information">
+                <h3 class="govuk-heading-m">How we will use your information</h3>
+                <p class="govuk-body">We receive your pupils’ personal data from your school.</p>
+                <p class="govuk-body">The aim of this project is to determine whether pupils can recall their times tables fluently,
+                    which is essential for future success in mathematics. It will help schools to identify pupils who have not yet mastered their times tables,
+                    so that additional support can be provided. Further <a class="govuk-link" href="https://www.gov.uk/government/collections/multiplication-tables-check">information about MTC</a> is available on GOV.UK.
+                </p>
+            </div>
+            <div id="nature-personal-data">
+                <h3 class="govuk-heading-m">The nature of personal data we will be using</h3>
+                <p class="govuk-body">
+                    The categories of your pupils’ personal data that we will be using for this project are:
                 </p>
                 <ul class="govuk-list govuk-list--bullet">
-                    <li>
-                        collect evidence on the performance of check items and forms to evaluate their comparable difficulty and inform future form construction
-                    </li>
-                    <li>
-                        develop and refine the live pilot digital service for implementing MTC as a final live service development
-                    </li>
+                    <li>full name</li>
+                    <li>gender</li>
+                    <li>date of birth</li>
+                    <li>unique pupil number (UPN)</li>
                 </ul>
-
-                <p class="govuk-body">
-                    As data processor, STA is responsible for securely storing and handling any personal data required to
-                    administer both the final trial and national pilot checks. We will keep data for only as long as it is
-                    required for research and operational purposes, and will regularly review retention of the data, in
-                    accordance and in line with the requirements of UK data protection legislation and the
-                    <a class="govuk-link" target="_blank" rel="noopener noreferrer"
-                       href="https://ico.org.uk/for-organisations/guide-to-the-general-data-protection-regulation-gdpr">
-                        General Data Protection Regulation (GDPR)
-                    </a>. <img alt="" src="/images/icon-link.png"/>
-                </p>
             </div>
-
-
-            <div id="data-collection-and-access">
-                <h3 class="govuk-heading-m">What data will be collected and who can access it?</h3>
-                <p class="govuk-body">We will collect and hold the following categories of data:</p>
-
-                <ul class="govuk-list govuk-list--bullet">
-                    <li>participating pupils’ names</li>
-                    <li>participating pupils’ dates of birth</li>
-                    <li>participating pupils’ unique pupil numbers</li>
-                    <li>names of participating schools</li>
-                </ul>
-                <p class="govuk-body">
-                    The MTC check will be completed online by all eligible year 4 pupils (age 8-9) who schools agree and
-                    decide to enter for the trial or national pilot in 2019.
-                </p>
-                <p class="govuk-body">
-                    STA will store the data collected securely within its own system and retain it in line with the agency’s
-                    data retention policy. Access within STA will be restricted to those employees who need to see the pupil
-                    data. Schools will also see the data for their participating pupils.
-                </p>
-            </div>
-
-
-            <div id="retaining-personal-data">
-                <h3 class="govuk-heading-m">How long will we keep your data?</h3>
-                <p class="govuk-body">
-                    STA will only keep personal data for as long as it is needed for the purpose of the trialling and
-                    service development of the live check. STA will retain the data for no longer than necessary, in
-                    accordance with the law, and will systematically review and manage retention. The data will be securely
-                    destroyed once it is no longer required. Please note, under section 33 of the Data Protection Act 1998,
-                    and in compliance with the relevant conditions, we can lawfully keep personal data processed purely for
-                    research purposes indefinitely.
-                </p>
-            </div>
-
             <div id="legal">
-                <h3 class="govuk-heading-m">What is the legal basis for collecting and processing the data?</h3>
+                <h3 class="govuk-heading-m">Why our use of your pupils’ personal data is lawful</h3>
                 <p class="govuk-body">
-                    The Data Protection Act 2018, Part 2 Chapter 2 Lawfulness of processing Section 8 (d) allows for when
-                    (data) processing is necessary for the exercise of a function of the Crown, a Minister of the Crown or a
-                    government department. For the processing of personal data, the relevant condition is Article 6 (1) (e)
-                    of GDPR.
+                    In order for our use of personal data to be lawful,
+                    we need to meet one (or more) conditions in the data protection legislation.
+                    For the purpose of this project, the relevant condition is:
+                </p>
+                <ul class="govuk-list govuk-list--bullet">
+                    <li>Article 6(1)(e) GDPR, to perform a public task as part of our function as a department</li>
+                </ul>
+                <p class="govuk-body">
+                    The Data Protection Act 2018, Part 2 Chapter 2 Lawfulness of processing Section 8 (d) allows
+                    for when (data) processing is necessary for the exercise of a function of the Crown,
+                    a Minister of the Crown or a government department.
                 </p>
             </div>
-
-            <div id="contact">
-                <h3 class="govuk-heading-m">Who can I contact about the use of personal data?</h3>
+            <div id="personal-data-available">
+                <h3 class="govuk-heading-m">Who we will make your pupils’ personal data available to</h3>
                 <p class="govuk-body">
-                    As an executive agency of the Department for Education (DfE), STA determines the purposes and means of
-                    processing personal data as part of the MTC project. You can find more information about this in DfE’s
-                    <a class="govuk-link" target="_blank" rel="noopener noreferrer"
-                       href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">
-                        personal information charter</a>. <img alt="" src="/images/icon-link.png"/></p>
+                    We sometimes need to make personal data available to other organisations.
                 </p>
                 <p class="govuk-body">
-                    If you have any questions about how we use your personal information, please
-                    <a class="govuk-link" target="_blank" rel="noopener noreferrer" href="https://www.gov.uk/contact-dfe">contact DfE</a>
-                    <img alt="" src="/images/icon-link.png"/> and
-                    quote ‘Use of multiplication tables check data’ as a reference. If you want to get in touch with the Data
-                    Protection Officer (DPO), please contact DfE and mark it ‘for the attention of the DPO’.
-                </p>
-                <p class="govuk-body">
-                    You have the right to lodge a complaint about data protection issues with the Information Commissioner’s
-                    Office. For more information, visit the
-                    <a class="govuk-link" target="_blank" rel="noopener noreferrer"
-                       href="https://ico.org.uk/make-a-complaint">ICO website</a>.
-                    <img alt="" src="/images/icon-link.png"/>
+                    Where we need to share your pupils’ personal data with others, we will only do this where the law allows us to.
                 </p>
             </div>
-            <span class="govuk-body govuk-!-font-size-16">Last updated 31 January 2019</span>
+            <div id="personal-data">
+                <h3 class="govuk-heading-m">How long we will keep your pupils’ personal data</h3>
+                <p class="govuk-body">
+                    DfE will keep your pupils’ personal data, that is the personal details listed above, alongside the pupils’ MTC score for 2 years.
+                </p>
+                <p class="govuk-body">
+                    The MTC database for each annual test cycle will (in line with STA data retention policy) be retained for a maximum of 2 years
+                    after each cycle (encrypted at rest in Enterprise Azure).
+                    This is in case we need to extract the data again (for disaster recovery purposes) or to retrieve
+                    to inform any subsequently received allegation of test maladministration. The data will be securely destroyed once it is no longer required.
+                    Please note, under section 33 of the Data Protection Act 1998, and in compliance with the relevant conditions,
+                    we can lawfully keep personal data processed purely for research purposes indefinitely,
+                    although the personal data at this point is now anonymised.
+                </p>
+            </div>
+            <div id="rights">
+                <h3 class="govuk-heading-m">Your data protection rights</h3>
+                <p class="govuk-body">
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">
+                        https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter
+                    </a>
+                </p>
+                <p class="govuk-body">
+                    Under the Data Protection Act 2018, you are entitled to ask if we hold information relating to you and ask for a copy,
+                    by making a ‘subject access request’.
+                </p>
+                <p class="govuk-body">
+                    For further information and how to request your data, please use the <a class="govuk-link" href="https://www.education.gov.uk/help/contactus">contact form</a> in the Personal Information Charter at
+                    <a class="govuk-link" href="https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter">https://www.gov.uk/government/organisations/department-for-education/about/personal-information-charter</a>
+                    under the ‘How to find out what personal information we hold about you’ section.
+                </p>
+                <p class="govuk-body">
+                    If you need to contact us regarding any of the above,
+                    please do so via the GOV.UK at: <a class="govuk-link" href="https://www.gov.uk/contact-dfe">https://www.gov.uk/contact-dfe</a>.
+                </p>
+                <p class="govuk-body">
+                    Further information about your data protection rights appears on the Information Commissioner’s website at:
+                    <a class="govuk-link" href="https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/">https://ico.org.uk/for-organisations/guide-to-data-protection/principle-6-rights/</a>.
+                </p>
+            </div>
+            <div id="last-updated">
+                <h3 class="govuk-heading-m">Last updated</h3>
+                <p class="govuk-body">
+                    We may need to update this privacy notice periodically so we recommend that you revisit this information from time to time. This version was last updated on 23 March 2020.
+                </p>
+            </div>
 
 
             <div class="govuk-back-to-top govuk-!-margin-top-9">
@@ -133,7 +138,7 @@
                 <nav role="navigation" aria-labelledby="subsection-title">
                     <ul class="govuk-list govuk-!-font-size-16">
                         <li>
-                            <a class="govuk-link" href="/cookies">Cookies</a>
+                            <a class="govuk-link" href="/cookies-form">Cookies on the multiplication tables check</a>
                         </li>
                     </ul>
                 </nav>


### PR DESCRIPTION
In order to add the new column `createdby_userId` and populate it as part of the check creation process the type needs to be dropped and the `spCreateChecks` procedure recreated.