### PR TITLE
feature/41115 hooks for admin and spa images

### DIFF
--- a/admin/hooks/post_push
+++ b/admin/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker tag $IMAGE_NAME $DOCKER_REPO:$SOURCE_COMMIT
+docker push $DOCKER_REPO:$SOURCE_COMMIT

--- a/admin/hooks/readme.md
+++ b/admin/hooks/readme.md
@@ -1,0 +1,5 @@
+# Hooks folder
+
+The hooks folder is used by the [STA MTC docker hub](https://hub.docker.com/orgs/stamtc/repositories) to trigger the push of additional tags to the images on creation.  By default docker hub only adds the `latest` tag which has very limited meaning.
+
+The `post_push` script adds the commit hash tag to ensure the set of MTC docker images can be explicitly sourced in the build pipeline.

--- a/pupil-spa/hooks/post_push
+++ b/pupil-spa/hooks/post_push
@@ -1,0 +1,3 @@
+#!/bin/bash
+docker tag $IMAGE_NAME $DOCKER_REPO:$SOURCE_COMMIT
+docker push $DOCKER_REPO:$SOURCE_COMMIT

--- a/pupil-spa/hooks/readme.md
+++ b/pupil-spa/hooks/readme.md
@@ -1,0 +1,5 @@
+# Hooks folder
+
+The hooks folder is used by the [STA MTC docker hub](https://hub.docker.com/orgs/stamtc/repositories) to trigger the push of additional tags to the images on creation.  By default docker hub only adds the `latest` tag which has very limited meaning.
+
+The `post_push` script adds the commit hash tag to ensure the set of MTC docker images can be explicitly sourced in the build pipeline.


### PR DESCRIPTION
Final commit to enable commit hash tag on images.
Proved working with pupil-api, this now adds it for admin & spa images