### PR TITLE
feature/44112 switch census function to use functions sql user

### DIFF
--- a/admin/README.md
+++ b/admin/README.md
@@ -71,7 +71,8 @@ if you have created one.  See [documentation](https://www.npmjs.com/package/dote
 The solution will fail to operate correctly without the following environment variables configured...
 
 * `SQL_TECH_SUPPORT_USER_PASSWORD` - **Required** password for the tech support sql azure user.  automatically created via sql migration
-* `SQL_PUPIL_CENSUS_USER_PASSWORD` - **Required** password for the pupil census sql azure user.  automatically created via sql migration
+* `SQL_FUNCTIONS_APP_USER` - **Required** username for the functions app sql user.  automatically created via sql migration
+* `SQL_FUNCTIONS_APP_USER_PASSWORD` - **Required** password for the functions app sql user.  automatically created via sql migration
 * `AZURE_STORAGE_CONNECTION_STRING` - **Required**  Azure Storage account connection string.  Upload is only enabled for
     production environments, but the queues are used by all environments
 

--- a/admin/README.md
+++ b/admin/README.md
@@ -71,6 +71,7 @@ if you have created one.  See [documentation](https://www.npmjs.com/package/dote
 The solution will fail to operate correctly without the following environment variables configured...
 
 * `SQL_TECH_SUPPORT_USER_PASSWORD` - **Required** password for the tech support sql azure user.  automatically created via sql migration
+* `SQL_PUPIL_CENSUS_USER_PASSWORD` - **Required** password for the pupil census sql azure user.  automatically created via sql migration
 * `SQL_FUNCTIONS_APP_USER` - **Required** username for the functions app sql user.  automatically created via sql migration
 * `SQL_FUNCTIONS_APP_USER_PASSWORD` - **Required** password for the functions app sql user.  automatically created via sql migration
 * `AZURE_STORAGE_CONNECTION_STRING` - **Required**  Azure Storage account connection string.  Upload is only enabled for

--- a/admin/data/sql/migrations/20201026153716.do.remove-census-user.js
+++ b/admin/data/sql/migrations/20201026153716.do.remove-census-user.js
@@ -1,0 +1,17 @@
+'use strict'
+
+const config = require('../../../config')
+
+const dropAzureUser = `DROP USER IF EXISTS ${config.Sql.PupilCensus.Username};`
+const dropLocalUser = `
+  DROP USER IF EXISTS ${config.Sql.PupilCensus.Username};
+  IF SUSER_ID ('[${config.Sql.PupilCensus.Username}]') IS NOT NULL DROP LOGIN [${config.Sql.PupilCensus.Username}];`
+
+// TODO test on sql azure
+module.exports.generateSql = function () {
+  if (config.Sql.Azure.Scale) {
+    return dropAzureUser
+  } else {
+    return dropLocalUser
+  }
+}

--- a/admin/data/sql/migrations/20201026153716.undo.remove-census-user.js
+++ b/admin/data/sql/migrations/20201026153716.undo.remove-census-user.js
@@ -1,0 +1,24 @@
+'use strict'
+
+const config = require('../../../config')
+
+const createAzureUser = `CREATE USER ${config.Sql.PupilCensus.Username} WITH PASSWORD ='${config.Sql.PupilCensus.Password}', DEFAULT_SCHEMA=[mtc_admin];`
+const createLocalUser = `
+  CREATE LOGIN ${config.Sql.PupilCensus.Username} WITH PASSWORD = '${config.Sql.PupilCensus.Password}';
+  USE ${config.Sql.Database};
+  CREATE USER ${config.Sql.PupilCensus.Username} FOR LOGIN ${config.Sql.PupilCensus.Username} WITH DEFAULT_SCHEMA = [mtc_admin];`
+
+// TODO test on sql azure
+module.exports.generateSql = function () {
+  if (!config.Sql.PupilCensus.Username) {
+    throw new Error('Missing \'config.Sql.PupilCensus.Username\'')
+  }
+  if (!config.Sql.PupilCensus.Password) {
+    throw new Error('Missing \'config.Sql.PupilCensus.Password\'')
+  }
+  if (config.Sql.Azure.Scale) {
+    return createAzureUser
+  } else {
+    return createLocalUser
+  }
+}

--- a/admin/data/sql/migrations/20201026161418.do.grant-function-user-census-perms.js
+++ b/admin/data/sql/migrations/20201026161418.do.grant-function-user-census-perms.js
@@ -1,0 +1,22 @@
+'use strict'
+
+const config = require('../../../config')
+
+module.exports.generateSql = function () {
+  return `
+    GRANT CREATE TABLE TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    CREATE SCHEMA [mtc_census_import];
+    GO
+    GRANT CONTROL ON schema::[mtc_census_import] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    GRANT UPDATE,INSERT ON [mtc_admin].[pupil] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    GRANT SELECT,UPDATE,INSERT ON [mtc_admin].[school] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    GRANT UPDATE ON [mtc_admin].[job] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    GRANT SELECT ON [mtc_admin].[jobStatus] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    `
+}

--- a/admin/data/sql/migrations/20201026161418.do.grant-function-user-census-perms.js
+++ b/admin/data/sql/migrations/20201026161418.do.grant-function-user-census-perms.js
@@ -6,8 +6,6 @@ module.exports.generateSql = function () {
   return `
     GRANT CREATE TABLE TO [${config.Sql.FunctionsApp.Username}];
     GO
-    CREATE SCHEMA [mtc_census_import];
-    GO
     GRANT CONTROL ON schema::[mtc_census_import] TO [${config.Sql.FunctionsApp.Username}];
     GO
     GRANT UPDATE,INSERT ON [mtc_admin].[pupil] TO [${config.Sql.FunctionsApp.Username}];

--- a/admin/data/sql/migrations/20201026161418.undo.grant-function-user-census-perms.js
+++ b/admin/data/sql/migrations/20201026161418.undo.grant-function-user-census-perms.js
@@ -1,0 +1,33 @@
+'use strict'
+
+const config = require('../../../config')
+
+module.exports.generateSql = function () {
+  return `
+    REVOKE SELECT,UPDATE,INSERT ON [mtc_admin].[school] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    REVOKE UPDATE ON [mtc_admin].[job] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    REVOKE SELECT ON [mtc_admin].[jobStatus] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    REVOKE UPDATE,INSERT ON [mtc_admin].[pupil] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    REVOKE CONTROL ON schema::[mtc_census_import] TO [${config.Sql.FunctionsApp.Username}];
+    GO
+    REVOKE CREATE TABLE TO [${config.Sql.FunctionsApp.Username}];
+    GO
+
+    DECLARE @sql NVARCHAR(4000) = ''
+
+    SELECT @sql += 'DROP TABLE ' + '[mtc_census_import].' + QUOTENAME(table_name) + ';'
+    from information_schema.tables
+    where table_schema = 'mtc_census_import'
+    and table_type = 'BASE TABLE'
+
+    -- PRINT @sql
+    Exec sp_executesql @sql
+    GO
+
+    DROP SCHEMA [mtc_census_import];
+    `
+}

--- a/admin/data/sql/migrations/20201026161418.undo.grant-function-user-census-perms.js
+++ b/admin/data/sql/migrations/20201026161418.undo.grant-function-user-census-perms.js
@@ -16,18 +16,5 @@ module.exports.generateSql = function () {
     GO
     REVOKE CREATE TABLE TO [${config.Sql.FunctionsApp.Username}];
     GO
-
-    DECLARE @sql NVARCHAR(4000) = ''
-
-    SELECT @sql += 'DROP TABLE ' + '[mtc_census_import].' + QUOTENAME(table_name) + ';'
-    from information_schema.tables
-    where table_schema = 'mtc_census_import'
-    and table_type = 'BASE TABLE'
-
-    -- PRINT @sql
-    Exec sp_executesql @sql
-    GO
-
-    DROP SCHEMA [mtc_census_import];
     `
 }

--- a/tslib/src/functions-throttled/census-import/index.ts
+++ b/tslib/src/functions-throttled/census-import/index.ts
@@ -17,8 +17,8 @@ const blobTrigger: AzureFunction = async function (context: Context, blob: any):
       port: config.Sql.port,
       requestTimeout: config.Sql.censusRequestTimeout,
       connectionTimeout: config.Sql.connectionTimeout,
-      user: config.Sql.PupilCensus.Username,
-      password: config.Sql.PupilCensus.Password,
+      user: config.Sql.user,
+      password: config.Sql.password,
       pool: {
         min: config.Sql.Pooling.MinCount,
         max: config.Sql.Pooling.MaxCount

--- a/tslib/src/functions-throttled/school-import/index.ts
+++ b/tslib/src/functions-throttled/school-import/index.ts
@@ -2,7 +2,6 @@ import { AzureFunction, Context } from '@azure/functions'
 import { performance } from 'perf_hooks'
 import { SchoolImportService } from './school-import.service'
 import * as mssql from 'mssql'
-import config from '../../config'
 import * as ConnectionPoolService from '../../sql/pool.service'
 import { SchoolImportJobResult } from './SchoolImportJobResult'
 
@@ -17,24 +16,7 @@ const blobTrigger: AzureFunction = async function schoolImportIndex (context: Co
   let errorOutput = ''
 
   try {
-    const sqlConfig: mssql.config = {
-      database: config.Sql.database,
-      server: config.Sql.server,
-      port: config.Sql.port,
-      requestTimeout: config.Sql.requestTimeout,
-      connectionTimeout: config.Sql.connectionTimeout,
-      user: config.Sql.user,
-      password: config.Sql.password,
-      pool: {
-        min: config.Sql.Pooling.MinCount,
-        max: config.Sql.Pooling.MaxCount
-      },
-      options: {
-        appName: config.Sql.options.appName,
-        encrypt: config.Sql.options.encrypt
-      }
-    }
-    pool = await ConnectionPoolService.getInstanceWithConfig(sqlConfig, context.log)
+    pool = await ConnectionPoolService.getInstance(context.log)
     const svc = new SchoolImportService(pool, jobResult, context.log)
     jobResult = await svc.process(blob)
     await pool.close()

--- a/tslib/src/sql/pool.service.ts
+++ b/tslib/src/sql/pool.service.ts
@@ -1,23 +1,19 @@
-import { config as sqlConfig, ConnectionPool } from 'mssql'
+import { ConnectionPool } from 'mssql'
 import { ConsoleLogger, ILogger } from '../common/logger'
 import config from '../config'
 
 let pool: ConnectionPool
 
-export async function getInstance (logger?: ILogger): Promise<ConnectionPool> {
-  return getInstanceWithConfig(config.Sql, logger)
-}
-
 // pool can still be connecting when first used...
 // https://github.com/tediousjs/node-mssql/issues/934
-export async function getInstanceWithConfig (sqlConfig: sqlConfig, logger?: ILogger): Promise<ConnectionPool> {
+export async function getInstance (logger?: ILogger): Promise<ConnectionPool> {
   if (logger === undefined) {
     logger = new ConsoleLogger()
   }
 
   // tslint:disable-next-line: strict-type-predicates
   if (pool === undefined) {
-    pool = new ConnectionPool(sqlConfig)
+    pool = new ConnectionPool(config.Sql)
     await pool.connect()
     pool.on('error', (error) => {
       logger?.error(`Sql Connection Pool Error Raised:${error.message}`)


### PR DESCRIPTION
Modify the census import function to use the new functions sql user account, instead of dedicated census user, which is to be removed.

A subsequent PR will be raised to baseline the sql migrations and remove the census user entirely.