### PR TITLE
removing unused gem

### DIFF
--- a/test/admin-hpa/Gemfile
+++ b/test/admin-hpa/Gemfile
@@ -29,4 +29,3 @@ gem 'colorize'
 gem 'lz_string'
 gem 'redis'
 gem "rack", ">= 2.2.3"
-gem 'browserstack-fast-selenium'

--- a/test/admin-hpa/Gemfile.lock
+++ b/test/admin-hpa/Gemfile.lock
@@ -21,8 +21,6 @@ GEM
     azure-storage-table (2.0.1)
       azure-storage-common (~> 2.0)
       nokogiri (~> 1.10.4)
-    browserstack-fast-selenium (1.0.2)
-      curb (= 0.9.9)
     browserstack-local (1.3.0)
     bson (4.8.2)
     builder (3.2.4)
@@ -73,7 +71,6 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    curb (0.9.9)
     diff-lcs (1.3)
     faraday (1.0.1)
       multipart-post (>= 1.2, < 3)
@@ -178,7 +175,6 @@ DEPENDENCIES
   azure-storage-blob
   azure-storage-queue
   azure-storage-table
-  browserstack-fast-selenium
   browserstack-local
   capybara (>= 3.32.2)
   capybara-screenshot (>= 1.0.24)

--- a/test/pupil-hpa/Gemfile
+++ b/test/pupil-hpa/Gemfile
@@ -31,4 +31,3 @@ gem 'azure-storage-blob'
 gem 'redis'
 gem 'lz_string'
 gem "rack", ">= 2.2.3"
-gem 'browserstack-fast-selenium'

--- a/test/pupil-hpa/Gemfile.lock
+++ b/test/pupil-hpa/Gemfile.lock
@@ -27,8 +27,6 @@ GEM
       azure-core (~> 0.1.13)
       azure-storage-common (~> 1.0)
       nokogiri (~> 1.6, >= 1.6.8)
-    browserstack-fast-selenium (1.0.2)
-      curb (= 0.9.9)
     browserstack-local (1.3.0)
     bson (4.5.0)
     builder (3.2.4)
@@ -80,7 +78,6 @@ GEM
       cucumber-core (~> 7.1, >= 7.1.0)
       cucumber-cucumber-expressions (~> 10.1, >= 10.1.0)
       cucumber-messages (~> 12.2, >= 12.2.0)
-    curb (0.9.9)
     diff-lcs (1.3)
     faraday (0.15.4)
       multipart-post (>= 1.2, < 3)
@@ -187,7 +184,6 @@ DEPENDENCIES
   azure-storage-blob
   azure-storage-queue
   azure-storage-table
-  browserstack-fast-selenium
   browserstack-local
   capybara (>= 3.32.2)
   capybara-screenshot (>= 1.0.23)


### PR DESCRIPTION
The browserstack-fast-selenium gem has a dependancy on the curb gem. We do not use browserstack-fast-selenium, it was left in and not removed after testing