### PR TITLE
bug/45311 disable xss protection for admin and pupil-spa

### DIFF
--- a/admin-assets/nginx/default.conf
+++ b/admin-assets/nginx/default.conf
@@ -57,10 +57,9 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-  # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
-  # this particular website if it was disabled by the user.
-  # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-  add_header X-XSS-Protection "1; mode=block";
+  # This is now known to expose a more advanced vulnerability, so is disabled.
+  # https://github.com/helmetjs/helmet/issues/230
+  add_header X-XSS-Protection "0";
 
   # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
   # you can tell the browser that it can only download content from the domains you explicitly allow

--- a/pupil-spa/nginx/default.conf
+++ b/pupil-spa/nginx/default.conf
@@ -79,10 +79,9 @@ server {
   add_header X-Content-Type-Options nosniff;
 
   # This header enables the Cross-site scripting (XSS) filter built into most recent web browsers.
-  # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
-  # this particular website if it was disabled by the user.
-  # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-  add_header X-XSS-Protection "1; mode=block";
+  # This is now known to expose a more advanced vulnerability, so is disabled.
+  # https://github.com/helmetjs/helmet/issues/230
+  add_header X-XSS-Protection "0";
 
   # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
   # you can tell the browser that it can only download content from the domains you explicitly allow


### PR DESCRIPTION
nginx config files were still setting header to active, this should now be disabled.