### PR TITLE
bug/45543 - verify API headers tests fix

### DIFF
--- a/admin-assets/nginx/example.conf
+++ b/admin-assets/nginx/example.conf
@@ -24,7 +24,7 @@ add_header X-Content-Type-Options nosniff;
 # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
 # this particular website if it was disabled by the user.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-add_header X-XSS-Protection "1; mode=block";
+add_header X-XSS-Protection "0";
 
 # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
 # you can tell the browser that it can only download content from the domains you explicitly allow

--- a/api_tests/spec/security_spec.rb
+++ b/api_tests/spec/security_spec.rb
@@ -13,7 +13,7 @@ describe 'Security API spec' do
       expect(response.headers['strict-transport-security']).to eql "max-age=31536000; includeSubDomains; preload"
       expect(response.headers['x-download-options']).to eql 'noopen'
       expect(response.headers['x-content-type-options']).to eql 'nosniff'
-      expect(response.headers['x-xss-protection']).to eql "1; mode=block"
+      expect(response.headers['x-xss-protection']).to eql "0"
       csp_array = ["default-src", "'self';", "script-src", "'self'", "'unsafe-inline'", "https://www.google-analytics.com",
                    "https://www.googletagmanager.com", "https://az416426.vo.msecnd.net", "font-src", "'self'",
                    "data: https://devassets-as-mtc.azurewebsites.net/", "style-src", "'self'", "'unsafe-inline'",
@@ -42,7 +42,7 @@ describe 'Security API spec' do
       expect(response.headers['x-dns-prefetch-control']).to eql 'off'
       expect(response.headers['x-download-options']).to eql 'noopen'
       expect(response.headers['x-frame-options']).to eql 'SAMEORIGIN'
-      expect(response.headers['x-xss-protection']).to eql "1; mode=block"
+      expect(response.headers['x-xss-protection']).to eql "0"
     end
   end
 

--- a/func-consumption/host.json
+++ b/func-consumption/host.json
@@ -22,7 +22,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "X-Download-Options": "noopen",
-        "X-XSS-Protection": "1; mode=block",
+        "X-XSS-Protection": "0",
         "X-DNS-Prefetch-Control": "off"
       }
     }

--- a/func-throttled/host.json
+++ b/func-throttled/host.json
@@ -23,7 +23,7 @@
         "X-Content-Type-Options": "nosniff",
         "X-Frame-Options": "SAMEORIGIN",
         "X-Download-Options": "noopen",
-        "X-XSS-Protection": "1; mode=block",
+        "X-XSS-Protection": "0",
         "X-DNS-Prefetch-Control": "off"
       }
     },

--- a/pupil-spa/nginx/example.conf
+++ b/pupil-spa/nginx/example.conf
@@ -24,7 +24,7 @@ add_header X-Content-Type-Options nosniff;
 # It's usually enabled by default anyway, so the role of this header is to re-enable the filter for
 # this particular website if it was disabled by the user.
 # https://www.owasp.org/index.php/List_of_useful_HTTP_headers
-add_header X-XSS-Protection "1; mode=block";
+add_header X-XSS-Protection "0";
 
 # with Content Security Policy (CSP) enabled(and a browser that supports it(http://caniuse.com/#feat=contentsecuritypolicy),
 # you can tell the browser that it can only download content from the domains you explicitly allow


### PR DESCRIPTION
Fix outstanding tests so that they correctly assert for `0` which disables the browser xss prevention check.