### PR TITLE
bug/46827 - tech support service bus queue shows total count instead of active

### DIFF
--- a/admin/services/data-access/service-bus-queue-metadata.service.js
+++ b/admin/services/data-access/service-bus-queue-metadata.service.js
@@ -41,7 +41,7 @@ async function getQueueMessageCount (queueName) {
   const props = await getQueueClient().getQueueRuntimeProperties(queueName)
   return {
     name: queueName,
-    activeMessageCount: props.totalMessageCount,
+    activeMessageCount: props.activeMessageCount,
     deadLetterCount: props.deadLetterMessageCount
   }
 }


### PR DESCRIPTION
data service was using wrong property `totalMessageCount` instead of `activeMessageCount`