### PR TITLE
47429 - [db] mask checkResult.mark with a better default

### DIFF
--- a/db/migrations/schema-objects/20210707115242.do.alter-mtc-results-checkresult-mark.sql
+++ b/db/migrations/schema-objects/20210707115242.do.alter-mtc-results-checkresult-mark.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    mtc_results.checkResult ALTER COLUMN mark ADD MASKED WITH (FUNCTION = 'random(99, 99)');

--- a/db/migrations/schema-objects/20210707115242.undo.alter-mtc-results-checkresult-mark.sql
+++ b/db/migrations/schema-objects/20210707115242.undo.alter-mtc-results-checkresult-mark.sql
@@ -1,0 +1,2 @@
+ALTER TABLE
+    mtc_results.checkResult ALTER COLUMN mark ADD MASKED WITH (FUNCTION = 'default()');


### PR DESCRIPTION
Was the default of 0
Now: 99

![Screenshot 2021-07-07 at 15 42 35](https://user-images.githubusercontent.com/13945069/124783188-c9b44b00-df3c-11eb-99b3-2926e3e924a3.png)
