### PR TITLE
feature/51567 enhance release pipeline

### DIFF
--- a/deploy/build-agent/what-is-my-ip.yml
+++ b/deploy/build-agent/what-is-my-ip.yml
@@ -4,8 +4,6 @@
 # https://aka.ms/yaml
 
 trigger: none
-variables:
-  MTC_INSTANCE:
 
 pool: 
   name: 'MTC'

--- a/deploy/build-agent/what-is-my-ip.yml
+++ b/deploy/build-agent/what-is-my-ip.yml
@@ -1,17 +1,17 @@
-# Starter pipeline
-# Start with a minimal pipeline that you can customize to build and deploy your code.
-# Add steps that build, run tests, deploy, and more:
-# https://aka.ms/yaml
+  # It is currently not possible to easily source the IP of a container instance
+  # This build task solves that problem by echoing it to the output stream
+  # USAGE
+  # =====
+  # the pool.demands section allows you to target a specific build server instance
+  # NOTE: ensure this custom demand is added to each build server, and has a unique matching value
 
 trigger: none
 
-pool: 
+pool:
   name: 'MTC'
   demands:
-  # the following demand allows you to target a specific build server instance
-  # ensure this custom demand is added to each build server, and is unique
   - mtc-instance -equals $(MTC_INSTANCE)
 
 steps:
-- script: curl 'https://api.ipify.org?format=json'
+- script: echo $(curl 'https://api.ipify.org?format=json')
   displayName: 'Reveal IPv4 Address'


### PR DESCRIPTION
add utility build task to allow us to source the IP address of the container instance running build services.

This is obscured in azure portal, and is useful for configuring firewalls ahead of release phases