### PR TITLE
bug/51752 school audit user display

### DIFF
--- a/admin/services/data-access/school-audit.data.service.js
+++ b/admin/services/data-access/school-audit.data.service.js
@@ -24,7 +24,7 @@ const service = {
       value: urlSlug
     }]
     const sql = `
-      SELECT sa.id, sa.createdAt, aot.auditOperation, ISNULL(u.identifier, 'system') as [user]
+      SELECT sa.id, sa.createdAt, aot.auditOperation, COALESCE(u.displayName, u.identifier, 'system') as [user]
       FROM [mtc_admin].[schoolAudit] sa
       LEFT OUTER JOIN [mtc_admin].[user] u ON
         u.id = sa.operationBy_userId


### PR DESCRIPTION
When viewing the school audit history in the SM area, the user.identifier value was displayed.

When the system uses DfE sign-in, this value is populated with a UUID.

This fix prioritises the user.displayName value, and falls back to the identifier.

'system' is displayed for non user changes.