### PR TITLE
bug/52271 multi pupil upload fails if blob container does not already exist

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -29,7 +29,7 @@
     "watch:integration": "yarn jest --watch --coverage=no --config ./tests-integration/jest.integration.config.js"
   },
   "mtc": {
-    "assets-version": "1a3a2c31afce137dfcba1d51690fef8b"
+    "assets-version": "66896ac7392c1a1f2d743877d2f9365d"
   },
   "engines": {
     "node": ">= 14"

--- a/admin/services/data-access/azure-blob.data.service.js
+++ b/admin/services/data-access/azure-blob.data.service.js
@@ -39,6 +39,7 @@ const blobService = {
   uploadData: async function uploadData (containerName, remoteFilename, data) {
     const client = BlobServiceClient.fromConnectionString(config.AZURE_STORAGE_CONNECTION_STRING)
     const containerClient = client.getContainerClient(containerName)
+    await containerClient.createIfNotExists()
     const blobClient = containerClient.getBlockBlobClient(remoteFilename)
     return blobClient.uploadData(data)
   },


### PR DESCRIPTION
creates the container if it does not already exist before uploading blob