### PR TITLE
Feature/security roll up 5 22

### DIFF
--- a/load-test/yarn.lock
+++ b/load-test/yarn.lock
@@ -790,7 +790,7 @@
 "@protobufjs/aspromise@^1.1.1", "@protobufjs/aspromise@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/aspromise/-/aspromise-1.1.2.tgz#9b8b0cc663d669a7d8f6f5d0893a14d348f30fbf"
-  integrity sha1-m4sMxmPWaafY9vXQiToU00jzD78=
+  integrity sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==
 
 "@protobufjs/base64@^1.1.2":
   version "1.1.2"
@@ -805,12 +805,12 @@
 "@protobufjs/eventemitter@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/eventemitter/-/eventemitter-1.1.0.tgz#355cbc98bafad5978f9ed095f397621f1d066b70"
-  integrity sha1-NVy8mLr61ZePntCV85diHx0Ga3A=
+  integrity sha512-j9ednRT81vYJ9OfVuXG6ERSTdEL1xVsNgqpkxMsbIabzSo3goCjDIveeGv5d03om39ML71RdmrGNjG5SReBP/Q==
 
 "@protobufjs/fetch@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/fetch/-/fetch-1.1.0.tgz#ba99fb598614af65700c1619ff06d454b0d84c45"
-  integrity sha1-upn7WYYUr2VwDBYZ/wbUVLDYTEU=
+  integrity sha512-lljVXpqXebpsijW71PZaCYeIcE5on1w5DlQy5WH6GLbFryLUrBD4932W/E2BSpfRJWseIL4v/KPgBFxDOIdKpQ==
   dependencies:
     "@protobufjs/aspromise" "^1.1.1"
     "@protobufjs/inquire" "^1.1.0"
@@ -818,27 +818,27 @@
 "@protobufjs/float@^1.0.2":
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/float/-/float-1.0.2.tgz#5e9e1abdcb73fc0a7cb8b291df78c8cbd97b87d1"
-  integrity sha1-Xp4avctz/Ap8uLKR33jIy9l7h9E=
+  integrity sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==
 
 "@protobufjs/inquire@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/inquire/-/inquire-1.1.0.tgz#ff200e3e7cf2429e2dcafc1140828e8cc638f089"
-  integrity sha1-/yAOPnzyQp4tyvwRQIKOjMY48Ik=
+  integrity sha512-kdSefcPdruJiFMVSbn801t4vFK7KB/5gd2fYvrxhuJYg8ILrmn9SKSX2tZdV6V+ksulWqS7aXjBcRXl3wHoD9Q==
 
 "@protobufjs/path@^1.1.2":
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@protobufjs/path/-/path-1.1.2.tgz#6cc2b20c5c9ad6ad0dccfd21ca7673d8d7fbf68d"
-  integrity sha1-bMKyDFya1q0NzP0hynZz2Nf79o0=
+  integrity sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==
 
 "@protobufjs/pool@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/pool/-/pool-1.1.0.tgz#09fd15f2d6d3abfa9b65bc366506d6ad7846ff54"
-  integrity sha1-Cf0V8tbTq/qbZbw2ZQbWrXhG/1Q=
+  integrity sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==
 
 "@protobufjs/utf8@^1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@protobufjs/utf8/-/utf8-1.1.0.tgz#a777360b5b39a1a2e5106f8e858f2fd2d060c570"
-  integrity sha1-p3c2C1s5oaLlEG+OhY8v0tBgxXA=
+  integrity sha512-Vvn3zZrhQZkkBE8LSuW3em98c0FwgO4nxzv6OdSxPKJIEKY2bGbHn+mhGIPerzI4twdxaP8/0+06HBpwf345Lw==
 
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
@@ -925,9 +925,9 @@
     "@types/node" "*"
 
 "@types/long@^4.0.1":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.1.tgz#459c65fa1867dafe6a8f322c4c51695663cc55e9"
-  integrity sha512-5tXH6Bx/kNGd3MgffdmP4dy2Z+G4eaXw0SE81Tq3BNadtnMR5/ySMzX4SLEzHJzSmPNn4HIdpQsBvXMUykr58w==
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/@types/long/-/long-4.0.2.tgz#b74129719fc8d11c01868010082d483b7545591a"
+  integrity sha512-MqTGEo5bj5t157U6fA/BiDynNkn0YknVdh48CMPkTSpFTVmvao5UQmm7uEF6xBEo7qIMAlY/JSleYaE6VOdpaA==
 
 "@types/minimatch@*", "@types/minimatch@^3.0.3":
   version "3.0.5"
@@ -943,9 +943,9 @@
     form-data "^3.0.0"
 
 "@types/node@*", "@types/node@>=13.7.0":
-  version "17.0.25"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.25.tgz#527051f3c2f77aa52e5dc74e45a3da5fb2301448"
-  integrity sha512-wANk6fBrUwdpY4isjWrKTufkrXdu1D2YHCot2fD/DfWxF5sMrVSA+KN7ydckvaTCh0HiqX9IVl0L5/ZoXg5M7w==
+  version "17.0.38"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.38.tgz#f8bb07c371ccb1903f3752872c89f44006132947"
+  integrity sha512-5jY9RhV7c0Z4Jy09G+NIDTsCZ5G0L5n+Z+p+Y7t5VJHM30bgwzSjVtlcBxqAj+6L/swIlvtOSzr8rBk/aNyV2g==
 
 "@types/node@^14.0.1":
   version "14.17.32"
@@ -4837,9 +4837,9 @@ promise-retry@^2.0.1:
     retry "^0.12.0"
 
 protobufjs@^6.10.2:
-  version "6.11.2"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.2.tgz#de39fabd4ed32beaa08e9bb1e30d08544c1edf8b"
-  integrity sha512-4BQJoPooKJl2G9j3XftkIXjoC9C0Av2NOrWmbLWT1vH32GcSUHjM0Arra6UfTsVyfMAuFzaLucXn1sadxJydAw==
+  version "6.11.3"
+  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-6.11.3.tgz#637a527205a35caa4f3e2a9a4a13ddffe0e7af74"
+  integrity sha512-xL96WDdCZYdU7Slin569tFX712BxsxslWwAfAhCYjQKGTq7dAU91Lomy6nLLhh/dyGhk/YH4TwTSRxTzhuHyZg==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"

--- a/test/admin-hpa/Gemfile
+++ b/test/admin-hpa/Gemfile
@@ -28,5 +28,5 @@ gem 'numbers_in_words', '>= 0.4.0'
 gem 'colorize'
 gem 'lz_string'
 gem 'redis'
-gem "rack", ">= 2.2.3"
+gem "rack", ">= 2.2.3.1"
 gem 'dotenv'

--- a/test/admin-hpa/Gemfile.lock
+++ b/test/admin-hpa/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (4.0.6)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.3)
@@ -214,7 +214,7 @@ DEPENDENCIES
   parallel_tests
   poltergeist (>= 1.18.1)
   pry
-  rack (>= 2.2.3)
+  rack (>= 2.2.3.1)
   rake
   rb-readline
   redis

--- a/test/admin-hpa/features/step_definitions/service_manager_pupil_search_steps.rb
+++ b/test/admin-hpa/features/step_definitions/service_manager_pupil_search_steps.rb
@@ -13,7 +13,7 @@ Then(/^the summary page is displayed with the status set to (.+) along with deta
   pupil_details = SqlDbHelper.pupil_details(@upn, @school_id)
   school_details = SqlDbHelper.find_school(@school_id)
   expect(pupil_summary_page.pupil_name.text).to eql pupil_details['lastName'] + ',' + pupil_details['foreName']
-  expect(pupil_summary_page.dob.text).to eql pupil_details['dateOfBirth'].strftime("%d %B %Y")
+  expect(pupil_summary_page.dob.text).to eql pupil_details['dateOfBirth'].strftime("%-d %b %Y")
   expect(pupil_summary_page.upn.text).to eql pupil_details['upn']
   expect(pupil_summary_page.pupil_id.text).to eql pupil_details['id'].to_s
   expect(pupil_summary_page.school.text).to eql school_details['name']
@@ -74,7 +74,7 @@ Then(/^I should see the pupil results page with a list of matched pupils$/) do
     pupil_row = pupil_search_page.pupil_results.pupil_row.find {|pupil| pupil.text.include? pupil_details['foreName']}
     school_details = SqlDbHelper.find_school(pupil_details['school_id'])
     expect(pupil_row.name.text).to eql pupil_details['lastName'] + ', ' + pupil_details['foreName']
-    expect(pupil_row.dob.text).to eql pupil_details['dateOfBirth'].strftime("%d %B %Y")
+    expect(pupil_row.dob.text).to eql pupil_details['dateOfBirth'].strftime("%-d %b %Y")
     expect(pupil_row.school.text).to eql school_details['name']
     expect(pupil_row.urn.text).to eql school_details['urn'].to_s
     expect(pupil_row.dfe_number.text).to eql school_details['dfeNumber'].to_s
@@ -157,7 +157,7 @@ Then(/^the summary page is displayed with the attendance status set to (.+) alon
   pupil_details = SqlDbHelper.pupil_details(@upn, @school_id)
   school_details = SqlDbHelper.find_school(@school_id)
   expect(pupil_summary_page.pupil_name.text).to eql pupil_details['lastName'] + ',' + pupil_details['foreName']
-  expect(pupil_summary_page.dob.text).to eql pupil_details['dateOfBirth'].strftime("%d %B %Y")
+  expect(pupil_summary_page.dob.text).to eql pupil_details['dateOfBirth'].strftime("%-d %b %Y")
   expect(pupil_summary_page.upn.text).to eql pupil_details['upn']
   expect(pupil_summary_page.pupil_id.text).to eql pupil_details['id'].to_s
   expect(pupil_summary_page.school.text).to eql school_details['name']

--- a/test/pupil-hpa/Gemfile
+++ b/test/pupil-hpa/Gemfile
@@ -29,5 +29,5 @@ gem 'azure-storage-queue', '>= 2.0.4'
 gem 'azure-storage-blob', '>= 2.0.3'
 gem 'redis'
 gem 'lz_string'
-gem "rack", ">= 2.2.3"
+gem "rack", ">= 2.2.3.1"
 gem 'dotenv'

--- a/test/pupil-hpa/Gemfile.lock
+++ b/test/pupil-hpa/Gemfile.lock
@@ -142,7 +142,7 @@ GEM
       method_source (~> 1.0)
     public_suffix (4.0.6)
     racc (1.6.0)
-    rack (2.2.3)
+    rack (2.2.3.1)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rake (13.0.3)
@@ -215,7 +215,7 @@ DEPENDENCIES
   parallel_tests
   poltergeist (>= 1.18.1)
   pry
-  rack (>= 2.2.3)
+  rack (>= 2.2.3.1)
   rake
   rb-readline
   redis


### PR DESCRIPTION
[Bump protobufjs from 6.11.2 to 6.11.3 in /load-test](https://github.com/DFEAGILEDEVOPS/MTC/commit/07cd82d51f27b523b38e9f4ac9a03703c4fdd503)
[fix: test/pupil-hpa/Gemfile to reduce vulnerabilities](https://github.com/DFEAGILEDEVOPS/MTC/commit/a9ccae81c596062690b2386030eac5f34b1ce12d)
[fix: test/admin-hpa/Gemfile to reduce vulnerabilities](https://github.com/DFEAGILEDEVOPS/MTC/commit/7f82b1913b2549a63bd93ce783ab6fb237e6b062)