### PR TITLE
bug/54798 assets image contains no assets

### DIFF
--- a/admin-assets/copy-assets.sh
+++ b/admin-assets/copy-assets.sh
@@ -3,6 +3,7 @@ cd ../admin
 node --version
 yarn --version
 yarn install --frozen-lockfile
+yarn build
 cd ../admin-assets
 rm -rf ./assets
 cp -a ../admin/public/. ./assets


### PR DESCRIPTION
- add `yarn build` to assets dockerfile now that install does not automatically trigger it