### PR TITLE
bug/54886 pupil auth failing to start

### DIFF
--- a/pupil-api/package.json
+++ b/pupil-api/package.json
@@ -33,6 +33,7 @@
     "moment": "^2.29.4",
     "morgan": "^1.9.0",
     "ramda": "^0.28.0",
+    "swagger-ui-express": "^4.3.0",
     "to-bool": "0.0.1",
     "uuid": "^8.3.2",
     "winston": "^3.8.1",
@@ -62,7 +63,6 @@
     "gulp": "^4.0.2",
     "jest": "^27.2.0",
     "node-mocks-http": "^1.7.0",
-    "swagger-ui-express": "^4.3.0",
     "ts-jest": "^27.1.4",
     "typescript": "4.3.5"
   }

--- a/pupil-api/src/App.ts
+++ b/pupil-api/src/App.ts
@@ -35,7 +35,7 @@ class App {
   public express: express.Application
 
   // Run configuration methods on the Express instance.
-  constructor () {
+  constructor() {
     this.express = express()
     this.middleware()
     this.routes()

--- a/pupil-api/src/App.ts
+++ b/pupil-api/src/App.ts
@@ -35,7 +35,7 @@ class App {
   public express: express.Application
 
   // Run configuration methods on the Express instance.
-  constructor() {
+  constructor () {
     this.express = express()
     this.middleware()
     this.routes()


### PR DESCRIPTION
move swagger deps to non dev dependency section, as always imported whether enabled or not