### PR TITLE
bug/58316 - NGINX try_files config issue on /sign-in

### DIFF
--- a/pupil-spa/nginx/default.conf
+++ b/pupil-spa/nginx/default.conf
@@ -30,7 +30,7 @@ server {
       # Prod
       rewrite ^(.*)index\.html$ /unsupported/browser.html redirect;
     }
-    try_files $uri $uri/ /sign-in =404;
+    try_files $uri $uri/ /index.html =404;
   }
 
   location ~ config\.json {


### PR DESCRIPTION
try_files directive was causing a 404 at the NGINX level, instead of passing it through to the hosted app