### PR TITLE
bug/59439 prevent attendance changes after HDF signed

### DIFF
--- a/admin/availability/middleware.js
+++ b/admin/availability/middleware.js
@@ -57,7 +57,6 @@ async function isPostLiveOrLaterCheckPhase (req, res, next) {
 
 async function refuseIfHdfSigned (req, res, next) {
   const school = await schoolService.findOneById(req.user.schoolId)
-  const checkWindow = await checkWindowV2Service.getActiveCheckWindow()
   const currentHdf = await hdfService.findLatestHdfForSchool(school.dfeNumber)
   if (currentHdf === undefined || currentHdf === null) return next()
   return next(new Error('HDF signed'))

--- a/admin/routes/pupils-not-taking-the-check.js
+++ b/admin/routes/pupils-not-taking-the-check.js
@@ -2,9 +2,9 @@ const roles = require('../lib/consts/roles')
 const express = require('express')
 const router = express.Router()
 const isAuthenticated = require('../authentication/middleware')
-const { isAdminWindowAvailable } = require('../availability/middleware')
-
+const { isAdminWindowAvailable, refuseIfHdfSigned } = require('../availability/middleware')
 const pupilsNotTakingTheCheck = require('../controllers/pupils-not-taking-the-check')
+
 
 router.get(
   '/select-pupils/:groupIds?',
@@ -28,6 +28,7 @@ router.get(
   '/remove/:pupilId',
   isAuthenticated([roles.teacher, roles.helpdesk, roles.staAdmin]),
   isAdminWindowAvailable,
+  refuseIfHdfSigned,
   (req, res, next) => pupilsNotTakingTheCheck.removePupilNotTakingCheck(req, res, next)
 )
 router.get(

--- a/admin/routes/pupils-not-taking-the-check.js
+++ b/admin/routes/pupils-not-taking-the-check.js
@@ -5,7 +5,6 @@ const isAuthenticated = require('../authentication/middleware')
 const { isAdminWindowAvailable, refuseIfHdfSigned } = require('../availability/middleware')
 const pupilsNotTakingTheCheck = require('../controllers/pupils-not-taking-the-check')
 
-
 router.get(
   '/select-pupils/:groupIds?',
   isAuthenticated([roles.teacher, roles.helpdesk, roles.staAdmin]),

--- a/admin/views/pupils-not-taking-the-check/select-pupils.ejs
+++ b/admin/views/pupils-not-taking-the-check/select-pupils.ejs
@@ -49,7 +49,7 @@
                             </td>
                             <td><%= pupil.reason || '-' %></td>
                             <td class="">
-                                <% if ((!isReadOnly || !hdfSubmitted) && pupil.attendanceCodeIsPrivileged === false) { %>
+                                <% if ((!isReadOnly && !hdfSubmitted) && pupil.attendanceCodeIsPrivileged === false) { %>
                                     <a href="/pupils-not-taking-the-check/remove/<%= pupil.urlSlug %>" class="govuk-link modal-link font-small">Remove reason</a>
                                 <% } %>
                             </td>

--- a/test/admin-hpa/features/pupil_not_taking_check.feature
+++ b/test/admin-hpa/features/pupil_not_taking_check.feature
@@ -147,3 +147,8 @@ Feature:
     When I want to add a reason for pupils not taking a check
     Then I can see pupil in the list for pupil for not taking check
 
+    @hdf
+    Scenario: Cannot remove reason for NTC when HDF has been signed
+      Given I the hdf has been signed
+      Then I should not be able to remove pupils who are NTC
+

--- a/test/admin-hpa/features/step_definitions/landing_page_steps.rb
+++ b/test/admin-hpa/features/step_definitions/landing_page_steps.rb
@@ -35,6 +35,7 @@ Then(/^I should be taken to the Manage a pupil page$/) do
 end
 
 Then(/^I should be taken to the Pupil register page$/) do
+  sleep 0.5
   expect(pupil_register_page).to be_displayed
 end
 

--- a/test/admin-hpa/features/step_definitions/pupil_not_taking_check.rb
+++ b/test/admin-hpa/features/step_definitions/pupil_not_taking_check.rb
@@ -334,3 +334,13 @@ Then(/^I should see related content on the pupils not taking a check page$/) do
   expect(pupils_not_taking_check_page).to have_guidance
   expect(pupils_not_taking_check_page).to have_access_arrangements
 end
+
+Given(/^I the hdf has been signed$/) do
+  step 'I am logged in'
+  step 'I am on the declaration submitted page'
+end
+
+Then(/^I should not be able to remove pupils who are NTC$/) do
+  pupils_not_taking_check_page.load
+  expect(pupils_not_taking_check_page.pupil_list.rows.first).to_not have_remove
+end

--- a/test/admin-hpa/features/support/page_objects/pupil_register_page.rb
+++ b/test/admin-hpa/features/support/page_objects/pupil_register_page.rb
@@ -1,7 +1,7 @@
 class PupilRegisterPage < SitePrism::Page
   set_url '/pupil-register/pupils-list'
 
-  element :heading, '.heading-xlarge', text: 'Pupil Register'
+  element :heading, '.govuk-heading-xl', text: "View, add or edit pupils on your school's register"
   element :add_pupil, 'a', text: 'Add pupil'
   element :add_multiple_pupil, 'a', text: 'Add multiple pupils'
   element :info_message, '.govuk-info-message', text: 'Changes to pupil details have been saved'

--- a/test/admin-hpa/features/support/page_objects/pupils_not_taking_check_page.rb
+++ b/test/admin-hpa/features/support/page_objects/pupils_not_taking_check_page.rb
@@ -18,7 +18,7 @@ class PupilsNotTakingCheckPage < SitePrism::Page
     sections :rows, 'tr' do
       element :name, 'label'
       element :reason, 'td:nth-of-type(2)'
-      element :remove, 'a', text: 'Remove'
+      element :remove, 'a', text: 'Remove reason'
       element :highlight, '.govuk-highlight-item'
     end
   end


### PR DESCRIPTION
bug in view logic was allowing removal of attendance codes after HDF signed
- fix view logic
- implement guard at routing level