### PR TITLE
bug/59558 PS Report: set attemptId to null if never logged in

### DIFF
--- a/test/pupil-hpa/features/a_ps_report.feature
+++ b/test/pupil-hpa/features/a_ps_report.feature
@@ -136,3 +136,11 @@ Feature:
     Given I have completed the check and have an unconsumed restart
     When I set a reason for NTC
     Then the correct pupil status is set
+
+  Scenario: AttemptId, TestDate and FormID should only be recorded when a pupil logs in
+    Given I have generated a pin for a pupil
+    Then I should see AttemptId, TestDate and FormID as null in the ps report
+
+  Scenario: AttemptId, TestDate and FormID are set to null when there is a NTC reason
+    Given I have marked a pupil as not taking check with the Left school reason
+    Then I should see AttemptId, TestDate and FormID as null in the ps report

--- a/test/pupil-hpa/features/step_definitions/ps_report_steps.rb
+++ b/test/pupil-hpa/features/step_definitions/ps_report_steps.rb
@@ -532,3 +532,14 @@ Then(/^the correct pupil status is set$/) do
   expect(ps_report_record['PupilStatus']).to eql 'Not taking the Check'
   p "PS_REPORT RECORD - " + ps_report_record["PupilId"].to_s
 end
+
+Then(/^I should see AttemptId, TestDate and FormID as null in the ps report$/) do
+  step 'the data sync and ps report function has run'
+  pupil_details = SqlDbHelper.pupil_details_using_school(@details_hash[:upn], @school_id)
+  ps_report_record = SqlDbHelper.get_ps_record_for_pupil(pupil_details['id'])
+  p "PS_REPORT RECORD - " + ps_report_record["PupilId"].to_s
+  ps_report_record = ps_report_record.map {|k, v| [k, (v.is_a?(BigDecimal) ? v.to_f : v)]}.to_h
+  expect(ps_report_record["AttemptId"]).to be_nil
+  expect(ps_report_record["FormID"]).to be_nil
+  expect(ps_report_record["TestDate"]).to be_nil
+end

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -725,6 +725,7 @@ describe('report line class', () => {
         expect(out.FormMark).toBeNull()
         expect(out.BrowserType).toBeNull()
         expect(out.DeviceID).toBeNull()
+        expect(out.answers).toHaveLength(0)
       })
     })
 

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -10,9 +10,8 @@ import { checkConfig } from './mocks/check-config'
 import { checkForm } from './mocks/check-form'
 import { device } from './mocks/device'
 import { events } from './mocks/events'
-import { Check, NotTakingCheckCode, RestartReasonCode } from '../../functions-ps-report/ps-report-2-pupil-data/models'
+import { NotTakingCheckCode, RestartReasonCode } from '../../functions-ps-report/ps-report-2-pupil-data/models'
 import { DfEAbsenceCode } from './models'
-import moment from 'moment'
 
 class ReportLineTest extends ReportLine {
   public getReasonNotTakingCheck (code: NotTakingCheckCode): string
@@ -565,7 +564,7 @@ describe('report line class', () => {
 
       test('the form name is mapped', () => {
         const out = sut.transform()
-        expect(out.FormID).toBe('Test check form 9')
+        expect(out.FormID).toBeNull()
       })
 
       test('the date the test was taken is mapped', () => {
@@ -661,7 +660,7 @@ describe('report line class', () => {
       beforeEach(() => {
         sut = new ReportLine(
           null,
-          null,
+          check,
           null,
           null,
           null,
@@ -709,6 +708,23 @@ describe('report line class', () => {
       test('the pupil status is set to Not taking the Check', () => {
         const out = sut.transform()
         expect(out.PupilStatus).toBe('Not taking the Check')
+      })
+
+      test('the check data is all set to null', () => {
+        const out = sut.transform()
+        expect(out.PauseLength).toBeNull()
+        expect(out.QDisplayTime).toBeNull()
+        expect(out.AttemptID).toBeNull()
+        expect(out.FormID).toBeNull()
+        expect(out.TestDate).toBeNull()
+        expect(out.TimeStart).toBeNull()
+        expect(out.TimeComplete).toBeNull()
+        expect(out.TimeTaken).toBeNull()
+        expect(out.RestartNumber).toBeNull()
+        expect(out.RestartReason).toBeNull()
+        expect(out.FormMark).toBeNull()
+        expect(out.BrowserType).toBeNull()
+        expect(out.DeviceID).toBeNull()
       })
     })
 

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -10,8 +10,9 @@ import { checkConfig } from './mocks/check-config'
 import { checkForm } from './mocks/check-form'
 import { device } from './mocks/device'
 import { events } from './mocks/events'
-import { NotTakingCheckCode, RestartReasonCode } from '../../functions-ps-report/ps-report-2-pupil-data/models'
+import { Check, NotTakingCheckCode, RestartReasonCode } from '../../functions-ps-report/ps-report-2-pupil-data/models'
 import { DfEAbsenceCode } from './models'
+import moment from 'moment'
 
 class ReportLineTest extends ReportLine {
   public getReasonNotTakingCheck (code: NotTakingCheckCode): string
@@ -557,9 +558,9 @@ describe('report line class', () => {
         )
       })
 
-      test('the attempt ID is mapped', () => {
+      test('the attempt ID is not mapped', () => {
         const out = sut.transform()
-        expect(out.AttemptID).toBe('xyz-def-988')
+        expect(out.AttemptID).toBeNull()
       })
 
       test('the form name is mapped', () => {

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
@@ -321,8 +321,17 @@ export class ReportLine {
       // that also covers the specific case of annulled pupils.
       return null
     }
-
     return this.check?.mark ?? null
+  }
+
+  private getAttemptId (): string | null {
+    if (this.check === null) {
+      return null
+    }
+    if (this.check?.pupilLoginDate === null) {
+      return null
+    }
+    return this.check.checkCode
   }
 
   private _transform (): void {
@@ -340,7 +349,7 @@ export class ReportLine {
     this._report.QDisplayTime = this.checkConfig?.questionTime ?? null // set to null rather than undefined
     this._report.PauseLength = this.checkConfig?.loadingTime ?? null // set to null rather than undefined
     this._report.AccessArr = this.getAccessArrangements()
-    this._report.AttemptID = this.check?.checkCode ?? null // set to null rather than undefined
+    this._report.AttemptID = this.getAttemptId()
     this._report.FormID = this.checkForm?.name ?? null // set to null rather than undefined
     this._report.TestDate = this.check?.pupilLoginDate ?? null // set to null if there is no check
     this._report.TimeStart = this.getTimeStart()

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
@@ -373,36 +373,35 @@ export class ReportLine {
       this._report.FormMark = this.getFormMark()
       this._report.BrowserType = this.getBrowser()
       this._report.DeviceID = this.device?.deviceId ?? null
+      // Question data
+      this.answers?.forEach(answer => {
+        const rla = new ReportLineAnswer()
+        rla.questionNumber = answer.questionNumber
+        rla.id = answer.question
+        rla.response = answer.response
+
+        if (answer.inputs !== null) {
+          rla.addInputs(answer.inputs)
+        }
+
+        rla.score = answer.isCorrect ? 1 : 0
+        rla.timeout = this.getTimeout(answer.questionNumber)
+        rla.timeoutResponse = this.getTimeoutResponse(answer)
+        rla.timeoutScore = this.getTimeoutScore(answer)
+        rla.loadTime = this.getLoadTime(answer)
+        rla.questionReaderStart = this.getQuestionReaderStart(answer)
+        rla.questionReaderEnd = this.getQuestionReaderEnd(answer)
+        rla.calculateOverallTime()
+        rla.calculateRecallTime()
+
+        // add to the report
+        this._report.answers.push(rla)
+      })
     }
     // other data
     this._report.PupilStatus = this.getPupilStatus()
     this._report.ImportedFromCensus = this.pupil.jobId !== null
     this._report.ToECode = this.school.typeOfEstablishmentCode
-
-    // Question data
-    this.answers?.forEach(answer => {
-      const rla = new ReportLineAnswer()
-      rla.questionNumber = answer.questionNumber
-      rla.id = answer.question
-      rla.response = answer.response
-
-      if (answer.inputs !== null) {
-        rla.addInputs(answer.inputs)
-      }
-
-      rla.score = answer.isCorrect ? 1 : 0
-      rla.timeout = this.getTimeout(answer.questionNumber)
-      rla.timeoutResponse = this.getTimeoutResponse(answer)
-      rla.timeoutScore = this.getTimeoutScore(answer)
-      rla.loadTime = this.getLoadTime(answer)
-      rla.questionReaderStart = this.getQuestionReaderStart(answer)
-      rla.questionReaderEnd = this.getQuestionReaderEnd(answer)
-      rla.calculateOverallTime()
-      rla.calculateRecallTime()
-
-      // add to the report
-      this._report.answers.push(rla)
-    })
   }
 
   public toObject (): IPsychometricReportLine {

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
@@ -334,7 +334,18 @@ export class ReportLine {
     return this.check.checkCode
   }
 
+  private getFormId (): string | null {
+    if (this.check === null) {
+      return null
+    }
+    if (this.check?.pupilLoginDate === null) {
+      return null
+    }
+    return this.checkForm?.name ?? null
+  }
+
   private _transform (): void {
+    // Pupil data
     this._report.PupilDatabaseId = this.pupil.id
     this._report.DOB = this.pupil.dateOfBirth
     this._report.Gender = this.pupil.gender.toUpperCase()
@@ -346,20 +357,24 @@ export class ReportLine {
     this._report.Estab = this.school.estabCode
     this._report.SchoolURN = this.school.urn
     this._report.LAnum = this.school.laCode
-    this._report.QDisplayTime = this.checkConfig?.questionTime ?? null // set to null rather than undefined
-    this._report.PauseLength = this.checkConfig?.loadingTime ?? null // set to null rather than undefined
     this._report.AccessArr = this.getAccessArrangements()
-    this._report.AttemptID = this.getAttemptId()
-    this._report.FormID = this.checkForm?.name ?? null // set to null rather than undefined
-    this._report.TestDate = this.check?.pupilLoginDate ?? null // set to null if there is no check
-    this._report.TimeStart = this.getTimeStart()
-    this._report.TimeComplete = this.getTimeComplete()
-    this._report.TimeTaken = this.getTimeTaken()
-    this._report.RestartNumber = this.check?.restartNumber ?? null // set to null if there is no check
-    this._report.RestartReason = ReportLine.getRestartReason(this.check?.restartReason ?? null) // map the code to the number
-    this._report.FormMark = this.getFormMark()
-    this._report.BrowserType = this.getBrowser()
-    this._report.DeviceID = this.device?.deviceId ?? null
+    // Check data
+    if (this._report.ReasonNotTakingCheck === null) {
+      this._report.QDisplayTime = this.checkConfig?.questionTime ?? null // set to null rather than undefined
+      this._report.PauseLength = this.checkConfig?.loadingTime ?? null // set to null rather than undefined
+      this._report.AttemptID = this.getAttemptId()
+      this._report.FormID = this.getFormId()
+      this._report.TestDate = this.check?.pupilLoginDate ?? null // set to null if there is no check
+      this._report.TimeStart = this.getTimeStart()
+      this._report.TimeComplete = this.getTimeComplete()
+      this._report.TimeTaken = this.getTimeTaken()
+      this._report.RestartNumber = this.check?.restartNumber ?? null // set to null if there is no check
+      this._report.RestartReason = ReportLine.getRestartReason(this.check?.restartReason ?? null) // map the code to the number
+      this._report.FormMark = this.getFormMark()
+      this._report.BrowserType = this.getBrowser()
+      this._report.DeviceID = this.device?.deviceId ?? null
+    }
+    // other data
     this._report.PupilStatus = this.getPupilStatus()
     this._report.ImportedFromCensus = this.pupil.jobId !== null
     this._report.ToECode = this.school.typeOfEstablishmentCode


### PR DESCRIPTION
- set AttemptId, FormID and TestDate to null if the pupil never logged into the check
- if an attendance code is present, do not initialise any of the check data fields