### PR TITLE
Bug/59557 restart number null or int

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -30,7 +30,7 @@
     "watch:integration": "yarn jest --watch --coverage=no --config ./tests-integration/jest.integration.config.js"
   },
   "mtc": {
-    "assets-version": "7b23a08c3f82a0bc95ec117e296ca74f"
+    "assets-version": "1826ad1466541e9827e727c5961ef46e"
   },
   "engines": {
     "node": ">= 16"

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/mocks/check-incomplete.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/mocks/check-incomplete.ts
@@ -12,7 +12,7 @@ export const check: Check = {
   mark: null,
   processingFailed: false,
   pupilLoginDate: null,
-  received: true,
+  received: false,
   restartNumber: 0,
   restartReason: null
 }

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/mocks/pupil-not-attending-annulled.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/mocks/pupil-not-attending-annulled.ts
@@ -1,0 +1,19 @@
+import { Pupil } from '../../ps-report-2-pupil-data/models'
+import moment from 'moment'
+
+export const pupil: Pupil = {
+  checkComplete: null,
+  currentCheckId: null,
+  dateOfBirth: moment.utc('2012-04-01'),
+  forename: 'Tester',
+  gender: 'M',
+  id: 3,
+  jobId: 1,
+  lastname: 'Person',
+  notTakingCheckReason: 'Results annulled',
+  notTakingCheckCode: 'ANLLD',
+  restartAvailable: false,
+  slug: 'abc-def-hij-klm',
+  schoolId: 3,
+  upn: 'TEST986'
+}

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -1,6 +1,7 @@
 import { ReportLine } from './report-line.class'
 import { pupil as pupilCompletedCheck } from './mocks/pupil-who-completed-a-check'
 import { pupil as pupilNotAttending } from './mocks/pupil-not-attending'
+import { pupil as pupilAnnulled } from './mocks/pupil-not-attending-annulled'
 import { pupil as pupilIncomplete } from './mocks/pupil-with-incomplete-check'
 import { pupil as pupilIncompleteCorrupt } from './mocks/pupil-not-attending-corrupt'
 import { pupil as pupilCompleteRestartAvailableCorrupt } from './mocks/pupil-complete-and-restart-available-corrupt'
@@ -682,6 +683,50 @@ describe('report line class', () => {
         const out = sut.transform()
         expect(out.answers).toStrictEqual([])
       })
+    })
+  })
+
+  describe('pupil is marked as annulled', () => {
+    let sut: ReportLine
+    beforeEach(() => {
+      sut = new ReportLine(
+        answers,
+        check,
+        checkConfig,
+        checkForm,
+        device,
+        events,
+        pupilAnnulled,
+        school
+      )
+    })
+
+    test('it is defined', () => {
+      expect(sut).toBeDefined()
+    })
+
+    test('the check data is initialised', () => {
+      const out = sut.transform()
+      expect(out.PauseLength).not.toBeNull()
+      expect(out.QDisplayTime).not.toBeNull()
+      expect(out.AttemptID).not.toBeNull()
+      expect(out.FormID).not.toBeNull()
+      expect(out.TestDate).not.toBeNull()
+      expect(out.TimeStart).not.toBeNull()
+      expect(out.FormMark).toBeNull()
+      expect(out.BrowserType).not.toBeNull()
+      expect(out.DeviceID).not.toBeNull()
+      expect(out.answers).not.toHaveLength(0)
+    })
+
+    test('the pupil has the annulled code', () => {
+      const out = sut.transform()
+      expect(out.ReasonNotTakingCheck).toBe('Q')
+    })
+
+    test('the pupil status is set to Not taking the Check', () => {
+      const out = sut.transform()
+      expect(out.PupilStatus).toBe('Not taking the Check')
     })
   })
 

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -315,7 +315,7 @@ describe('report line class', () => {
         expect(out.TimeTaken).toBe(19.877)
       })
 
-      test('the number of restarts is mapped', () => {
+      test('the number of restarts is an integer', () => {
         const out = sut.transform()
         expect(out.RestartNumber).toBe(2)
       })
@@ -589,7 +589,7 @@ describe('report line class', () => {
 
       test('the number of restarts is mapped', () => {
         const out = sut.transform()
-        expect(out.RestartNumber).toBe(0)
+        expect(out.RestartNumber).toBeNull()
       })
 
       test('the restart reason is mapped', () => {
@@ -708,6 +708,11 @@ describe('report line class', () => {
       test('the pupil status is set to Not taking the Check', () => {
         const out = sut.transform()
         expect(out.PupilStatus).toBe('Not taking the Check')
+      })
+
+      test('the restart number is set to null', () => {
+        const out = sut.transform()
+        expect(out.RestartNumber).toBeNull()
       })
     })
 

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.spec.ts
@@ -736,12 +736,12 @@ describe('report line class', () => {
 
       beforeEach(() => {
         sut = new ReportLine(
-          null,
+          answers,
           check,
-          null,
-          null,
-          null,
-          null,
+          checkConfig,
+          checkForm,
+          device,
+          events,
           pupilNotAttending,
           school
         )

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
@@ -325,6 +325,14 @@ export class ReportLine {
     return this.check?.mark ?? null
   }
 
+  private getRestartNumber (): number | null {
+    const status = this.getPupilStatus()
+    if (status === 'Complete') {
+      return this.check?.restartNumber ?? null
+    }
+    return null
+  }
+
   private _transform (): void {
     this._report.PupilDatabaseId = this.pupil.id
     this._report.DOB = this.pupil.dateOfBirth
@@ -346,7 +354,7 @@ export class ReportLine {
     this._report.TimeStart = this.getTimeStart()
     this._report.TimeComplete = this.getTimeComplete()
     this._report.TimeTaken = this.getTimeTaken()
-    this._report.RestartNumber = this.check?.restartNumber ?? null // set to null if there is no check
+    this._report.RestartNumber = this.getRestartNumber()
     this._report.RestartReason = ReportLine.getRestartReason(this.check?.restartReason ?? null) // map the code to the number
     this._report.FormMark = this.getFormMark()
     this._report.BrowserType = this.getBrowser()

--- a/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
+++ b/tslib/src/functions-ps-report/ps-report-3-transformer/report-line.class.ts
@@ -373,7 +373,7 @@ export class ReportLine {
     this._report.LAnum = this.school.laCode
     this._report.AccessArr = this.getAccessArrangements()
     // Check data
-    if (this._report.ReasonNotTakingCheck === null) {
+    if (this._report.ReasonNotTakingCheck === null || this._report.ReasonNotTakingCheck === 'Q') {
       this._report.QDisplayTime = this.checkConfig?.questionTime ?? null // set to null rather than undefined
       this._report.PauseLength = this.checkConfig?.loadingTime ?? null // set to null rather than undefined
       this._report.AttemptID = this.getAttemptId()


### PR DESCRIPTION
Mod for mtc_results.psychometricReport. RestartNumber will be:

1. NULL for pupils set to not taking check
2. NULL for incomplete pupils
3. a number for pupils who have logged in to take a check (whether we received it back or not)