### PR TITLE
Feature/63741 rename gender to sex in ctf file

### DIFF
--- a/admin/package.json
+++ b/admin/package.json
@@ -30,7 +30,7 @@
     "watch:integration": "yarn jest --watch --coverage=no --config ./tests-integration/jest.integration.config.js"
   },
   "mtc": {
-    "assets-version": "f851de6df574116d072fa2d6717f93ad"
+    "assets-version": "b7c2e0eae8c9e8705534436649dc79b7"
   },
   "engines": {
     "node": ">= 18"

--- a/admin/package.json
+++ b/admin/package.json
@@ -30,7 +30,7 @@
     "watch:integration": "yarn jest --watch --coverage=no --config ./tests-integration/jest.integration.config.js"
   },
   "mtc": {
-    "assets-version": "b7c2e0eae8c9e8705534436649dc79b7"
+    "assets-version": "f851de6df574116d072fa2d6717f93ad"
   },
   "engines": {
     "node": ">= 18"

--- a/admin/services/ctf/ctf.service.js
+++ b/admin/services/ctf/ctf.service.js
@@ -129,7 +129,7 @@ const ctfService = {
         .ele('Surname').txt(p.lastName.toUpperCase()).up()
         .ele('Forename').txt(p.foreName.toUpperCase()).up()
         .ele('DOB').txt(dob).up()
-        .ele('Gender').txt(p.gender.toUpperCase()).up()
+        .ele('Sex').txt(p.gender.toUpperCase()).up()
         .ele('StageAssessments')
         .ele('KeyStage')
         .ele('Stage').txt('KS2').up()

--- a/admin/services/ctf/ctf.service.spec.js
+++ b/admin/services/ctf/ctf.service.spec.js
@@ -303,8 +303,8 @@ describe('ctfService', () => {
     })
 
     test('the Pupil element has a Gender', () => {
-      expect(obj.CTfile.CTFpupilData.Pupil).toHaveProperty('Gender')
-      expect(obj.CTfile.CTFpupilData.Pupil.Gender).toEqual(mockPupilData[0].gender)
+      expect(obj.CTfile.CTFpupilData.Pupil).toHaveProperty('Sex')
+      expect(obj.CTfile.CTFpupilData.Pupil.Sex).toEqual(mockPupilData[0].gender)
     })
 
     test('the Pupil element has a StageAssessments element', () => {


### PR DESCRIPTION
Example pupil output tag:

```
    <Pupil>
      <UPN>G801200001010</UPN>
      <Surname>BREWER</Surname>
      <Forename>JULIANA</Forename>
      <DOB>2014-01-20</DOB>
      <Sex>M</Sex>
      <StageAssessments>
        <KeyStage>
          <Stage>KS2</Stage>
          <StageAssessment>
            <Locale>ENG</Locale>
            <Year>2017</Year>
            <Subject>MAT</Subject>
            <Method>TT</Method>
            <Component>MTC</Component>
            <ResultStatus>R</ResultStatus>
            <ResultQualifier>MT</ResultQualifier>
            <Result>Z</Result>
          </StageAssessment>
        </KeyStage>
      </StageAssessments>
    </Pupil>
```
