### PR TITLE
Bug/65517 axios requests failing to talk to azure functions API

### DIFF
--- a/admin/app.js
+++ b/admin/app.js
@@ -131,6 +131,10 @@ const pupilStatus = require('./routes/pupil-status')
 const websiteOffline = require('./routes/website-offline')
 const techSupport = require('./routes/tech-support')
 const roles = require('./lib/consts/roles')
+// globally configure ipv4 for all axios request uses...
+const axios = require('axios')
+const http = require('http')
+axios.defaults.httpAgent = new http.Agent({ family: 4 })
 
 setupBrowserSecurity(app)
 

--- a/admin/package.json
+++ b/admin/package.json
@@ -32,7 +32,7 @@
     "watch:integration": "yarn jest --watch --coverage=no --config ./tests-integration/jest.integration.config.js"
   },
   "mtc": {
-    "assets-version": "6a569a48061e8e7844eee749fb4527b3"
+    "assets-version": "5eb463baa90e81b0b79de4acfc4a8096"
   },
   "engines": {
     "node": ">= 18"

--- a/admin/services/data-access/sync-results-resync.data.service.js
+++ b/admin/services/data-access/sync-results-resync.data.service.js
@@ -2,10 +2,8 @@
 
 const sqlService = require('./sql.service')
 const R = require('ramda')
-const axios = require('axios')
 const config = require('../../config')
-const http = require('http')
-axios.defaults.httpAgent = new http.Agent({ family: 4 })
+const axios = require('axios')
 
 const functionUrl = `${config.Functions.Throttled.BaseAdminUrl}/sync-results-init`
 const requestConfig = {

--- a/admin/services/data-access/sync-results-resync.data.service.js
+++ b/admin/services/data-access/sync-results-resync.data.service.js
@@ -4,6 +4,8 @@ const sqlService = require('./sql.service')
 const R = require('ramda')
 const axios = require('axios')
 const config = require('../../config')
+const http = require('http')
+axios.defaults.httpAgent = new http.Agent({ family: 4 })
 
 const functionUrl = `${config.Functions.Throttled.BaseAdminUrl}/sync-results-init`
 const requestConfig = {
@@ -32,7 +34,7 @@ const service = {
   },
 
   callSyncResultsInitFunction: async function callSyncResultsInitFunction (message) {
-    const response = await axios.post(functionUrl, { input: JSON.stringify(message) }, requestConfig)
+    const response = await axios.post(functionUrl, message, requestConfig)
     if (response.status !== 202) {
       throw new Error(`request to ${functionUrl} failed: ${response.status} - ${response.statusText}`)
     }


### PR DESCRIPTION
Axios requests fail with a refused connection.

Forcing IPV4 fixes the issue.
Configured at global level to ensure parity across solution. 