### PR TITLE
Reverting changes done as part of 66709 - see PR 3019

### DIFF
--- a/db/migrations/schema-objects/20210129090329.do.create-ps-report-table.sql
+++ b/db/migrations/schema-objects/20210129090329.do.create-ps-report-table.sql
@@ -25,7 +25,7 @@ CREATE TABLE [mtc_results].[psychometricReport]
  LANum                SMALLINT          NULL,
  AttemptId            UNIQUEIDENTIFIER  NULL,
  FormID               NVARCHAR(64)      NULL,
- TestDate             DATETIMEOFFSET(3) NULL,
+ TestDate             DATE              NULL,
  TimeStart            DATETIMEOFFSET(3) NULL,
  TimeComplete         DATETIMEOFFSET(3) NULL,
  TimeTaken            DECIMAL(9, 3)     NULL, -- SQL Server does not have a duration type; store durations as seconds with the fractional part in milliseconds

--- a/db/migrations/schema-objects/20240103120853.undo.rename-table-psychometricreport.sql
+++ b/db/migrations/schema-objects/20240103120853.undo.rename-table-psychometricreport.sql
@@ -22,7 +22,7 @@ CREATE TABLE [mtc_results].[psychometricReport](
 	[LANum] [smallint] NULL,
 	[AttemptId] [uniqueidentifier] NULL,
 	[FormID] [nvarchar](64) NULL,
-	[TestDate] [datetimeoffset](3) NULL,
+	[TestDate] [date] NULL,
 	[TimeStart] [datetimeoffset](3) NULL,
 	[TimeComplete] [datetimeoffset](3) NULL,
 	[TimeTaken] [decimal](9, 3) NULL,

--- a/tslib/src/functions-ps-report/ps-report-3b-stage-csv-file/csv-transform.spec.ts
+++ b/tslib/src/functions-ps-report/ps-report-3b-stage-csv-file/csv-transform.spec.ts
@@ -32,7 +32,7 @@ describe('CsvTransformer Class', () => {
         LAnum: 999,
         AttemptID: 'attempt ID',
         FormID: 'form ID',
-        TestDate: moment('2020-06-29T07:49:35.637Z'),
+        TestDate: moment('2020-06-29'),
         TimeStart: moment('2020-06-29T07:49:35.637Z'),
         TimeComplete: moment('2020-06-29T07:49:35.637Z').add(2, 'minutes'),
         TimeTaken: 223.45,
@@ -214,7 +214,7 @@ describe('CsvTransformer Class', () => {
     test('it outputs the test date', () => {
       const s = sut.transform()
       const res = CSV.parse(s)
-      expect(res[0][24]).toBe('2020-06-29T07:49:35.637Z')
+      expect(res[0][24]).toBe('2020-06-29')
     })
 
     test('it outputs the time start', () => {

--- a/tslib/src/functions-ps-report/ps-report-3b-stage-csv-file/csv-transformer.ts
+++ b/tslib/src/functions-ps-report/ps-report-3b-stage-csv-file/csv-transformer.ts
@@ -113,7 +113,7 @@ export class CsvTransformer {
       d.LAnum,
       d.AttemptID,
       d.FormID,
-      d.TestDate?.toISOString(),
+      d.TestDate?.format('YYYY-MM-DD'),
       d.TimeStart?.toISOString(),
       d.TimeComplete?.toISOString(),
       d.TimeTaken,

--- a/tslib/src/functions-ps-report/ps-report-4-writer/ps-report-writer.service.ts
+++ b/tslib/src/functions-ps-report/ps-report-4-writer/ps-report-writer.service.ts
@@ -90,7 +90,7 @@ export class PsReportWriterService {
         LANum smallint NULL,
         AttemptId uniqueidentifier NULL,
         FormID nvarchar(64) NULL,
-        TestDate datetimeoffset(3) NULL,
+        TestDate date NULL,
         TimeStart datetimeoffset(7) NULL,
         TimeComplete datetimeoffset(7) NULL,
         TimeTaken decimal(9,3) NULL,

--- a/z_spikes/ps-report-sql-tactical/ps-report-2019.sql
+++ b/z_spikes/ps-report-sql-tactical/ps-report-2019.sql
@@ -27,7 +27,7 @@ CREATE TABLE [mtc_analysis].[PsReport2019](
 	[LA Num] smallint NULL,
 	[AttemptId] [nvarchar](64) NULL,
 	[Form ID] [nvarchar](64) NULL,
-	[TestDate] [nvarchar](16) NULL,
+	[TestDate] int NULL,
 	[TimeStart] [nvarchar](16) NULL,
 	[TimeComplete] [nvarchar](16) NULL,
 	[TimeTaken] [nvarchar](16) NULL,


### PR DESCRIPTION
Reverted - SQL changes shouldn't be added to existing migration scripts

https://github.com/DFEAGILEDEVOPS/MTC/pull/3019